### PR TITLE
Add Squiz.WhiteSpace.CastSpacing sniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ How to install
     ```
     {
     	"require-dev": {
-    		"wikibase/wikibase-codesniffer": "0.1.0"
+    		"wikibase/wikibase-codesniffer": "^0.2.0"
     	},
     	"scripts": {
     		"test": [

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase CodeSniffer standards changelog
 
+## 0.2.0 (2017-04-27)
+
+* Added `Squiz.WhiteSpace.CastSpacing` sniff.
+
 ## 0.1.0 (2017-04-26)
 
-* Initial tagged release
+* Initial tagged release.

--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -76,6 +76,9 @@
 		<exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
 	</rule> -->
 
+	<!-- Disallows spaces in ( int )$var type casts. -->
+	<rule ref="Squiz.WhiteSpace.CastSpacing" />
+
 	<!-- Enforces one empty line before and after each method in a class. -->
 	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
 		<properties>


### PR DESCRIPTION
This disallows spaces in `( int )$var` type casts. I believe we can all agree on having this as a strict rule that makes Jenkins go red, can we?