### PR TITLE
Update base MediaWiki rule set to 0.8.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,8 +1,26 @@
 # Wikibase CodeSniffer standards changelog
 
-## 0.2.0 (2017-04-27)
+## 0.2.0 (2017-10-11)
 
-* Added `Squiz.WhiteSpace.CastSpacing` sniff.
+* Added custom sniffs:
+	* `Wikibase.Commenting.ClassLevelDocumentation`
+	* `Wikibase.Commenting.DisallowedDocTags`
+	* `Wikibase.Commenting.RedundantVarName`
+	* `Wikibase.Namespaces.UnnecessaryUse`
+	* `Wikibase.Namespaces.UnusedUse`
+	* `Wikibase.Usage.InArrayUsage`
+* Updated the base MediaWiki rule set from 0.7 to 0.8.1. This adds the following sniffs:
+	* `Generic.Formatting.NoSpaceAfterCast`
+	* `MediaWiki.ExtraCharacters.ParenthesesAroundKeyword`
+	* `MediaWiki.NamingConventions.LowerCamelFunctionsName`
+	* `MediaWiki.Usage.DbrQueryUsage`
+	* `MediaWiki.Usage.ExtendClassUsage`
+	* `MediaWiki.Usage.SuperGlobalsUsage`
+	* `MediaWiki.WhiteSpace.SpaceBeforeClassBrace`
+	* `MediaWiki.WhiteSpace.SpaceBeforeControlStructureBrace`
+	* `PSR2.Methods.FunctionClosingBrace`
+* Added `Squiz.Operators.ValidLogicalOperators`
+* Added `Squiz.WhiteSpace.CastSpacing`
 
 ## 0.1.0 (2017-04-26)
 

--- a/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
+++ b/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
@@ -5,6 +5,8 @@
  * non-empty documentation comment. Comments with empty PHPDoc tags like "@inheritDoc" are still
  * considered empty.
  *
+ * @since 0.2.0
+ *
  * @license GPL-2.0+
  * @author Thiemo Mättig
  */

--- a/Wikibase/Sniffs/Commenting/DisallowedDocTagsSniff.php
+++ b/Wikibase/Sniffs/Commenting/DisallowedDocTagsSniff.php
@@ -4,6 +4,8 @@
  * Custom sniff that reports deprecated PHPDoc tags (e.g. known misspellings) and replaces them with
  * their preferred counterparts.
  *
+ * @since 0.2.0
+ *
  * @license GPL-2.0+
  * @author Thiemo Mättig
  */

--- a/Wikibase/Sniffs/Commenting/RedundantVarNameSniff.php
+++ b/Wikibase/Sniffs/Commenting/RedundantVarNameSniff.php
@@ -4,6 +4,8 @@
  * Custom sniff that reports and repairs "@var" documentations of class properties that repeat the
  * variable name, which is unnecessary.
  *
+ * @since 0.2.0
+ *
  * @license GPL-2.0+
  * @author Thiemo Mättig
  */

--- a/Wikibase/Sniffs/Namespaces/UnnecessaryUseSniff.php
+++ b/Wikibase/Sniffs/Namespaces/UnnecessaryUseSniff.php
@@ -4,6 +4,8 @@
  * Custom sniff that checks and removes unnecessary "use" clauses that are in the same namespace as
  * the rest of the code.
  *
+ * @since 0.2.0
+ *
  * @license GPL-2.0+
  * @author Thiemo Mättig
  */

--- a/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
+++ b/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
@@ -4,6 +4,8 @@
  * Custom sniff that finds and removes "use" clauses that are neither used in code nor in
  * documentation.
  *
+ * @since 0.2.0
+ *
  * @license GPL-2.0+
  * @author Thiemo Mättig
  */

--- a/Wikibase/Sniffs/Usage/InArrayUsageSniff.php
+++ b/Wikibase/Sniffs/Usage/InArrayUsageSniff.php
@@ -4,6 +4,8 @@
  * Custom sniff that finds unnecessary slow in_array() that can be replaced with array_key_exists()
  * or isset().
  *
+ * @since 0.2.0
+ *
  * @license GPL-2.0+
  * @author Thiemo Mättig
  */

--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -4,6 +4,27 @@
 		https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml
 		-->
 	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<!-- The function comment sniff is way to rigorous about way to many details that need
+			exceptions:
+			* It complains when "@param <type> $<var>" is not followed by a comment, even if type
+			  and variable name are fully self-explanatory. We do have 3000+ of these in the
+			  Wikibase code base.
+			* It complains about missing documentation on fully self-explanatory function headers
+			  with strict type hints.
+			* It complains about missing documentation if there is a proper @see tag.
+			* It complains about duplicate spaces in "@param <type>  $<var>", but removing these
+			  doesn't make the code easier to read.
+			* It does not understand "@param <type> [$optional,…]. -->
+		<exclude name="MediaWiki.Commenting.FunctionComment" />
+
+		<!-- We disagree with the idea of certain characters making comments "illegal" and blocking
+			patches from being merged. This behaves especially bad on commented out code. -->
+		<exclude name="MediaWiki.Commenting.IllegalSingleLineComment" />
+
+		<!-- Starting a function's body with an empty line can be helpful after a very large header.
+			The code is not guaranteed to be easier to read if this is disallowed. -->
+		<exclude name="MediaWiki.WhiteSpace.DisallowEmptyLineFunctions" />
+
 		<!-- Even if we encourage to use spaces in comments, we don't think this sniff should block
 			patches from being merged. -->
 		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment" />
@@ -11,10 +32,6 @@
 
 	<!-- NOTE: We purposely decided against additional Generic.CodeAnalysis.… sniffs, because they
 		all have possible exceptions, and are not meant to block patches from being merged. -->
-
-	<!-- Enforces to use curly brackets after if ( … ) and other control structures, even if only a
-		single token follows. -->
-	<rule ref="Generic.ControlStructures" />
 
 	<!-- Disallows any content outside of <?php … ?> tags. -->
 	<rule ref="Generic.Files.InlineHTML" />
@@ -37,6 +54,11 @@
 
 	<rule ref="Generic.PHP.CharacterBeforePHPOpeningTag" />
 
+	<rule ref="MediaWiki.NamingConventions.LowerCamelFunctionsName">
+		<!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
+		<exclude-pattern>tests*Test*\.php</exclude-pattern>
+	</rule>
+
 	<!-- See http://www.php-fig.org/psr/psr-1/ -->
 	<rule ref="PSR1">
 		<!-- Entry points typically have side effects, which is why this sniff is a "should" and not
@@ -48,7 +70,7 @@
 		<exclude-pattern>tests*Test*\.php</exclude-pattern>
 	</rule>
 
-	<!-- Enforces a single blank line at the end of the file. See
+	<!-- Disallows ?> and enforces a single blank line at the end of the file. See
 		http://www.php-fig.org/psr/psr-2/#files -->
 	<rule ref="PSR2.Files" />
 
@@ -75,9 +97,6 @@
 	<!-- NOTE: Do not add the Squiz.Strings.DoubleQuoteUsage sniff. Even if we encourage to prefer
 		single quotes, we don't think double quotes should block patches from being merged. -->
 
-	<!-- Disallows spaces in ( int )$var type casts. -->
-	<rule ref="Squiz.WhiteSpace.CastSpacing" />
-
 	<!-- Enforces one empty line before and after each method in a class. -->
 	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
 		<properties>
@@ -85,6 +104,9 @@
 			<property name="spacing" value="1" />
 		</properties>
 	</rule>
+
+	<!-- Disallows the use of AND and OR in favor of && and ||. -->
+	<rule ref="Squiz.Operators.ValidLogicalOperators" />
 
 	<!-- Makes sure operators are surrounded by spaces. This includes comparisons, assignments, and
 		calculations like 1 / 60. -->

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"require": {
 		"php": ">=5.5.9",
-		"mediawiki/mediawiki-codesniffer": ">=0.7 <0.8"
+		"mediawiki/mediawiki-codesniffer": "0.8.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8"
@@ -18,6 +18,7 @@
 	"scripts": {
 		"fix": "phpcbf",
 		"test": [
+			"@validate --no-interaction",
 			"phpcs -p -s",
 			"phpunit"
 		]


### PR DESCRIPTION
MediaWiki CodeSniffer 0.8.1 is the last that depends on PHP_CodeSniffer 2.x. To make further updates possible I need to rewrite all custom sniffs as well as the test suite first. I would like to do this in later patches, and do the much more trivial update from 0.7.x to 0.8.1 you can see here first.