### PR TITLE
Exclude node_modules and sub-extensions by default

### DIFF
--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -99,5 +99,7 @@
 
 	<arg name="extensions" value="php" />
 	<arg name="encoding" value="utf8" />
+	<exclude-pattern type="relative">^extensions/</exclude-pattern>
+	<exclude-pattern type="relative">^node_modules/</exclude-pattern>
 	<exclude-pattern type="relative">^vendor/</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
Stuff in vendor/… and node_modules/… directories are external dependencies. Stuff in extensions/… directories are MediaWiki extensions (or "sub-extensions" of Wikibase). All this must always be checked separately.