### PR TITLE
Custom sniff to enforce class level documentation

### DIFF
--- a/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
+++ b/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
@@ -3,6 +3,9 @@
 /**
  * Custom sniff that reports classes, interfaces, and traits that are not directly preceded by a
  * documentation comment.
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
  */
 class Wikibase_Sniffs_Commenting_ClassLevelDocumentationSniff implements PHP_CodeSniffer_Sniff {
 
@@ -22,14 +25,14 @@ class Wikibase_Sniffs_Commenting_ClassLevelDocumentationSniff implements PHP_Cod
 			if ( $previous !== $stackPtr - 2 || $tokens[$stackPtr - 1]['content'] !== "\n" ) {
 				$phpcsFile->addWarning(
 					'Unexpected whitespace after class level documentation',
-					$stackPtr,
+					$stackPtr - 1,
 					'Whitespace'
 				);
 			}
 		} elseif ( $tokens[$previous]['code'] === T_COMMENT ) {
 			$phpcsFile->addError(
 				'Regular comment found instead of class level documentation',
-				$stackPtr,
+				$previous,
 				'Regular'
 			);
 		} else {

--- a/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
+++ b/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Custom sniff that reports classes, interfaces, and traits that are not directly preceded by a
+ * documentation comment.
+ */
+class Wikibase_Sniffs_Commenting_ClassLevelDocumentationSniff implements PHP_CodeSniffer_Sniff {
+
+	public function register() {
+		return [
+			T_CLASS,
+			T_INTERFACE,
+			T_TRAIT,
+		];
+	}
+
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$comment = $phpcsFile->findPrevious( T_DOC_COMMENT_CLOSE_TAG, $stackPtr - 1, $stackPtr - 2 );
+
+		if ( $comment === false ) {
+			$phpcsFile->addError( 'Class level documentation missing', $stackPtr, 'Missing' );
+		}
+	}
+
+}

--- a/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
+++ b/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
@@ -15,9 +15,24 @@ class Wikibase_Sniffs_Commenting_ClassLevelDocumentationSniff implements PHP_Cod
 	}
 
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$comment = $phpcsFile->findPrevious( T_DOC_COMMENT_CLOSE_TAG, $stackPtr - 1, $stackPtr - 2 );
+		$tokens = $phpcsFile->getTokens();
+		$previous = $phpcsFile->findPrevious( T_WHITESPACE, $stackPtr - 1, null, true );
 
-		if ( $comment === false ) {
+		if ( $tokens[$previous]['code'] === T_DOC_COMMENT_CLOSE_TAG ) {
+			if ( $previous !== $stackPtr - 2 || $tokens[$stackPtr - 1]['content'] !== "\n" ) {
+				$phpcsFile->addWarning(
+					'Unexpected whitespace after class level documentation',
+					$stackPtr,
+					'Whitespace'
+				);
+			}
+		} elseif ( $tokens[$previous]['code'] === T_COMMENT ) {
+			$phpcsFile->addError(
+				'Regular comment found instead of class level documentation',
+				$stackPtr,
+				'Regular'
+			);
+		} else {
 			$phpcsFile->addError( 'Class level documentation missing', $stackPtr, 'Missing' );
 		}
 	}

--- a/Wikibase/Sniffs/Commenting/RedundantVarNameSniff.php
+++ b/Wikibase/Sniffs/Commenting/RedundantVarNameSniff.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Custom sniff …
+ */
+class Wikibase_Sniffs_Commenting_RedundantVarNameSniff implements PHP_CodeSniffer_Sniff {
+
+	public function register() {
+		return [
+			T_VARIABLE,
+		];
+	}
+
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		if ( $tokens[$stackPtr]['level'] !== 1 ) {
+			return;
+		}
+
+		$variableName = $tokens[$stackPtr]['content'];
+
+		$commentClose = $phpcsFile->findPrevious(
+			[
+				T_PRIVATE,
+				T_PROTECTED,
+				T_PUBLIC,
+				T_WHITESPACE,
+			],
+			$stackPtr - 1,
+			null,
+			true
+		);
+
+		if ( $tokens[$commentClose]['code'] !== T_DOC_COMMENT_CLOSE_TAG ) {
+			return;
+		}
+
+		$commentOpen = $phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, $commentClose - 1 );
+		for ( $i = $commentOpen + 1; $i < $commentClose; $i++ ) {
+			if ( $tokens[$i]['code'] === T_DOC_COMMENT_TAG
+				&& strtolower( $tokens[$i]['content'] ) === '@var'
+				&& preg_match(
+					'/^(\S+\s+)?' . preg_quote( $variableName, '/' ) . '\b/is',
+					$tokens[$i + 2]['content']
+				)
+			) {
+				$phpcsFile->addError(
+					'Found redundant variable name in @var',
+					$stackPtr,
+					'Redundant'
+				);
+				return;
+			}
+		}
+	}
+
+}

--- a/Wikibase/Sniffs/Commenting/RedundantVarNameSniff.php
+++ b/Wikibase/Sniffs/Commenting/RedundantVarNameSniff.php
@@ -1,57 +1,60 @@
 <?php
 
 /**
- * Custom sniff …
+ * Custom sniff that checks if the "@var" documentation of a class property repeats the variable
+ * name, which is unnecessary.
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
  */
 class Wikibase_Sniffs_Commenting_RedundantVarNameSniff implements PHP_CodeSniffer_Sniff {
 
 	public function register() {
-		return [
-			T_VARIABLE,
-		];
+		return [ T_DOC_COMMENT_TAG ];
 	}
 
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
-		if ( $tokens[$stackPtr]['level'] !== 1 ) {
+		if ( strtolower( $tokens[$stackPtr]['content'] ) !== '@var' ) {
 			return;
 		}
 
-		$variableName = $tokens[$stackPtr]['content'];
+		$variablePtr = $phpcsFile->findNext( T_VARIABLE, $stackPtr + 1 );
+		if ( $variablePtr === false ) {
+			return;
+		}
+		$variableName = $tokens[$variablePtr]['content'];
 
-		$commentClose = $phpcsFile->findPrevious(
-			[
-				T_PRIVATE,
-				T_PROTECTED,
-				T_PUBLIC,
-				T_WHITESPACE,
-			],
-			$stackPtr - 1,
-			null,
+		$visibilityPtr = $phpcsFile->findPrevious(
+			T_WHITESPACE,
+			$variablePtr - 1,
+			$stackPtr + 1,
+			true
+		);
+		if ( !in_array( $tokens[$visibilityPtr]['code'], [ T_PRIVATE, T_PROTECTED, T_PUBLIC ] ) ) {
+			return;
+		}
+
+		$stringPtr = $phpcsFile->findNext(
+			T_DOC_COMMENT_WHITESPACE,
+			$stackPtr + 1,
+			$visibilityPtr - 1,
 			true
 		);
 
-		if ( $tokens[$commentClose]['code'] !== T_DOC_COMMENT_CLOSE_TAG ) {
-			return;
-		}
-
-		$commentOpen = $phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, $commentClose - 1 );
-		for ( $i = $commentOpen + 1; $i < $commentClose; $i++ ) {
-			if ( $tokens[$i]['code'] === T_DOC_COMMENT_TAG
-				&& strtolower( $tokens[$i]['content'] ) === '@var'
-				&& preg_match(
-					'/^(\S+\s+)?' . preg_quote( $variableName, '/' ) . '\b/is',
-					$tokens[$i + 2]['content']
-				)
-			) {
-				$phpcsFile->addError(
-					'Found redundant variable name in @var',
-					$stackPtr,
-					'Redundant'
-				);
-				return;
-			}
+		if ( $stringPtr !== false
+			&& $tokens[$stringPtr]['code'] === T_DOC_COMMENT_STRING
+			&& preg_match(
+				'/^(\S+\s+)?' . preg_quote( $variableName, '/' ) . '\b/is',
+				$tokens[$stringPtr]['content']
+			)
+		) {
+			$phpcsFile->addError(
+				'Found redundant variable name in @var',
+				$stringPtr,
+				'Redundant'
+			);
 		}
 	}
 

--- a/Wikibase/Sniffs/Commenting/ReturnsTagSniff.php
+++ b/Wikibase/Sniffs/Commenting/ReturnsTagSniff.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Custom sniff that checks for usages of "@returns" with an "s" instead of the preferred "@return".
+ */
+class Wikibase_Sniffs_Commenting_ReturnsTagSniff implements PHP_CodeSniffer_Sniff {
+
+	public function register() {
+		return [ T_FUNCTION ];
+	}
+
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$commentClose = $phpcsFile->findPrevious( T_WHITESPACE, $stackPtr - 1, null, true );
+
+		if ( $tokens[$commentClose]['code'] !== T_DOC_COMMENT_CLOSE_TAG ) {
+			return;
+		}
+
+		$commentOpen = $phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, $commentClose - 1 );
+		for ( $i = $commentOpen + 1; $i < $commentClose; $i++ ) {
+			if ( $tokens[$i]['code'] === T_DOC_COMMENT_TAG
+				&& strtolower( $tokens[$i]['content'] ) === '@returns'
+			) {
+				$phpcsFile->addError( 'Found @returns instead of @return', $stackPtr, 'Returns' );
+				return;
+			}
+		}
+	}
+
+}

--- a/Wikibase/Sniffs/Commenting/ReturnsTagSniff.php
+++ b/Wikibase/Sniffs/Commenting/ReturnsTagSniff.php
@@ -2,29 +2,21 @@
 
 /**
  * Custom sniff that checks for usages of "@returns" with an "s" instead of the preferred "@return".
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
  */
 class Wikibase_Sniffs_Commenting_ReturnsTagSniff implements PHP_CodeSniffer_Sniff {
 
 	public function register() {
-		return [ T_FUNCTION ];
+		return [ T_DOC_COMMENT_TAG ];
 	}
 
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
-		$commentClose = $phpcsFile->findPrevious( T_WHITESPACE, $stackPtr - 1, null, true );
 
-		if ( $tokens[$commentClose]['code'] !== T_DOC_COMMENT_CLOSE_TAG ) {
-			return;
-		}
-
-		$commentOpen = $phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, $commentClose - 1 );
-		for ( $i = $commentOpen + 1; $i < $commentClose; $i++ ) {
-			if ( $tokens[$i]['code'] === T_DOC_COMMENT_TAG
-				&& strtolower( $tokens[$i]['content'] ) === '@returns'
-			) {
-				$phpcsFile->addError( 'Found @returns instead of @return', $stackPtr, 'Returns' );
-				return;
-			}
+		if ( strtolower( $tokens[$stackPtr]['content'] ) === '@returns' ) {
+			$phpcsFile->addError( 'Found @returns instead of @return', $stackPtr, 'Returns' );
 		}
 	}
 

--- a/Wikibase/Tests/Commenting/ClassLevelDocumentation.php
+++ b/Wikibase/Tests/Commenting/ClassLevelDocumentation.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This should not be reported as an error, but everything below should.
+ */
+class MyCompliantClass {
+}
+
+/**
+ * To much whitespace between comment and class.
+ */
+
+class ToMuchWhiteSpace {
+}
+
+/*
+ * This is not a PHPDoc comment.
+ */
+class NotAPhpDocComment {
+}
+
+interface UndocumentedInterface {
+}
+
+class UndocumentedClass {
+}
+
+trait UndocumentedTrait {
+}
+
+class UndocumentedImplementation implements UndocumentedInterface {
+}
+
+class UndocumentedSubClass extends UndocumentedClass {
+}
+
+namespace UndocumentedNamespace {
+	class UndocumentedClassInNamespace {
+	}
+}

--- a/Wikibase/Tests/Commenting/ClassLevelDocumentation.php
+++ b/Wikibase/Tests/Commenting/ClassLevelDocumentation.php
@@ -7,6 +7,16 @@ class MyCompliantClass {
 }
 
 /**
+ * Missing newline between comment and class.
+ */class MissingNewline {
+}
+
+/**
+ * Wrong whitespace character between comment and class.
+ */ class WrongWhitespace {
+}
+
+/**
  * To much whitespace between comment and class.
  */
 

--- a/Wikibase/Tests/Commenting/ClassLevelDocumentation.php.expected
+++ b/Wikibase/Tests/Commenting/ClassLevelDocumentation.php.expected
@@ -1,0 +1,8 @@
+ 13 | ERROR | Class level documentation missing
+ 19 | ERROR | Class level documentation missing
+ 22 | ERROR | Class level documentation missing
+ 25 | ERROR | Class level documentation missing
+ 28 | ERROR | Class level documentation missing
+ 31 | ERROR | Class level documentation missing
+ 34 | ERROR | Class level documentation missing
+ 38 | ERROR | Class level documentation missing

--- a/Wikibase/Tests/Commenting/ClassLevelDocumentation.php.expected
+++ b/Wikibase/Tests/Commenting/ClassLevelDocumentation.php.expected
@@ -1,7 +1,7 @@
  11 | WARNING | Unexpected whitespace after class level documentation
  16 | WARNING | Unexpected whitespace after class level documentation
- 23 | WARNING | Unexpected whitespace after class level documentation
- 29 | ERROR   | Regular comment found instead of class level documentation
+ 22 | WARNING | Unexpected whitespace after class level documentation
+ 28 | ERROR   | Regular comment found instead of class level documentation
  32 | ERROR   | Class level documentation missing
  35 | ERROR   | Class level documentation missing
  38 | ERROR   | Class level documentation missing

--- a/Wikibase/Tests/Commenting/ClassLevelDocumentation.php.expected
+++ b/Wikibase/Tests/Commenting/ClassLevelDocumentation.php.expected
@@ -1,8 +1,10 @@
- 13 | ERROR | Class level documentation missing
- 19 | ERROR | Class level documentation missing
- 22 | ERROR | Class level documentation missing
- 25 | ERROR | Class level documentation missing
- 28 | ERROR | Class level documentation missing
- 31 | ERROR | Class level documentation missing
- 34 | ERROR | Class level documentation missing
- 38 | ERROR | Class level documentation missing
+ 11 | WARNING | Unexpected whitespace after class level documentation
+ 16 | WARNING | Unexpected whitespace after class level documentation
+ 23 | WARNING | Unexpected whitespace after class level documentation
+ 29 | ERROR   | Regular comment found instead of class level documentation
+ 32 | ERROR   | Class level documentation missing
+ 35 | ERROR   | Class level documentation missing
+ 38 | ERROR   | Class level documentation missing
+ 41 | ERROR   | Class level documentation missing
+ 44 | ERROR   | Class level documentation missing
+ 48 | ERROR   | Class level documentation missing

--- a/Wikibase/Tests/Commenting/RedundantVarName.php
+++ b/Wikibase/Tests/Commenting/RedundantVarName.php
@@ -1,0 +1,50 @@
+<?php
+
+class Example {
+
+	/**
+	 * @var bool
+	 */
+	private $uncommented;
+
+	/**
+	 * @var bool This is just text and should not be reported as an error.
+	 */
+	private $validComment;
+
+	/**
+	 * @var bool $mentioningOtherVariables should be allowed in such a comment.
+	 */
+	private $someOtherVariableName;
+
+	/**
+	 * @var bool Also, $mentioning the same variable name later in the sentence should be allowed.
+	 */
+	private $mentioning;
+
+	/**
+	 * @var bool $notTheSameVariableName should be allowed.
+	 */
+	private $not;
+
+	/**
+	 * @var bool $redundantVariableName
+	 */
+	private $redundantVariableName;
+
+	/**
+	 * @var bool $redundantWithComment after the variable name.
+	 */
+	private $redundantWithComment;
+
+	/**
+	 * @var $redundantBeforeType bool
+	 */
+	private $redundantBeforeType;
+
+	private function __construct() {
+		/** @var bool $local */
+		$local = true;
+	}
+
+}

--- a/Wikibase/Tests/Commenting/RedundantVarName.php.expected
+++ b/Wikibase/Tests/Commenting/RedundantVarName.php.expected
@@ -1,0 +1,3 @@
+ 33 | ERROR | Found redundant variable name in @var
+ 38 | ERROR | Found redundant variable name in @var
+ 43 | ERROR | Found redundant variable name in @var

--- a/Wikibase/Tests/Commenting/RedundantVarName.php.expected
+++ b/Wikibase/Tests/Commenting/RedundantVarName.php.expected
@@ -1,3 +1,3 @@
- 33 | ERROR | Found redundant variable name in @var
- 38 | ERROR | Found redundant variable name in @var
- 43 | ERROR | Found redundant variable name in @var
+ 31 | ERROR | Found redundant variable name in @var
+ 36 | ERROR | Found redundant variable name in @var
+ 41 | ERROR | Found redundant variable name in @var

--- a/Wikibase/Tests/Commenting/ReturnsTag.php
+++ b/Wikibase/Tests/Commenting/ReturnsTag.php
@@ -1,0 +1,28 @@
+<?php
+
+function noDocComment() {
+}
+
+/**
+ * @return void This is fine.
+ */
+function validReturnTag() {
+}
+
+/**
+ * @returns void This should be reported for using "@returns" with an "s" instead of "@return".
+ */
+function lowerCaseReturnsTag() {
+}
+
+/**
+ * @Returns void Reporting should be case-insensitive.
+ */
+function upperCaseReturnsTag() {
+}
+
+/*
+ * @returns void This is not a PHPDoc comment and should be ignored.
+ */
+function notADocComment() {
+}

--- a/Wikibase/Tests/Commenting/ReturnsTag.php.expected
+++ b/Wikibase/Tests/Commenting/ReturnsTag.php.expected
@@ -1,2 +1,2 @@
- 15 | ERROR | Found @returns instead of @return
- 21 | ERROR | Found @returns instead of @return
+ 13 | ERROR | Found @returns instead of @return
+ 19 | ERROR | Found @returns instead of @return

--- a/Wikibase/Tests/Commenting/ReturnsTag.php.expected
+++ b/Wikibase/Tests/Commenting/ReturnsTag.php.expected
@@ -1,0 +1,2 @@
+ 15 | ERROR | Found @returns instead of @return
+ 21 | ERROR | Found @returns instead of @return

--- a/Wikibase/Tests/WikibaseStandardTest.php
+++ b/Wikibase/Tests/WikibaseStandardTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Wikibase\CodeSniffer\Tests;
+
+use PHP_CodeSniffer_CLI;
+use PHPUnit_Framework_TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Test runner for custom Wikibase CodeSniffer sniffs. This is copied from the MediaWiki CodeSniffer
+ * code repository, but simplified a lot.
+ */
+class WikibaseStandardTest extends PHPUnit_Framework_TestCase {
+
+	public static function provideTestCases() {
+		$tests = [];
+		$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( __DIR__ ) );
+
+		/** @var SplFileInfo $file */
+		foreach ( $iterator as $file ) {
+			if ( !$file->isFile()
+				|| $file->getExtension() !== 'php'
+				|| $file->getPath() === __DIR__
+			) {
+				continue;
+			}
+
+			$shortName = $file->getBasename( '.' . $file->getExtension() );
+			$sniff = 'Wikibase.' . basename( $file->getPath() ) . '.' . $shortName;
+
+			$tests[$shortName] = [ $sniff, $file->getPathname() ];
+		}
+
+		return $tests;
+	}
+
+	/**
+	 * @dataProvider provideTestCases
+	 */
+	public function testCodeSnifferStandardFiles( $sniff, $file ) {
+		$phpcs = new PHP_CodeSniffer_CLI();
+		$options = [
+			'standard' => __DIR__ . '/..',
+			'sniffs' => [ $sniff ],
+			'files' => [ $file ],
+		];
+
+		ob_start();
+		$phpcs->process( $options );
+		$actual = ob_get_clean();
+		$actual = preg_replace( '/\A.*--\n(?= )/ms', '', $actual );
+		$actual = preg_replace( '/^--+\n\n.*/ms', '', $actual );
+
+		$expectedFile = $file . '.expected';
+		if ( !file_exists( $expectedFile ) ) {
+			file_put_contents( $expectedFile, $actual );
+		}
+
+		$expected = file_get_contents( $expectedFile );
+		$this->assertSame( $expected, $actual );
+	}
+
+}

--- a/Wikibase/Tests/WikibaseStandardTest.php
+++ b/Wikibase/Tests/WikibaseStandardTest.php
@@ -45,12 +45,13 @@ class WikibaseStandardTest extends PHPUnit_Framework_TestCase {
 			'standard' => __DIR__ . '/..',
 			'sniffs' => [ $sniff ],
 			'files' => [ $file ],
+			'reportWidth' => 120,
 		];
 
 		ob_start();
 		$phpcs->process( $options );
 		$actual = ob_get_clean();
-		$actual = preg_replace( '/\A.*--\n(?= )/ms', '', $actual );
+		$actual = preg_replace( '/^.*--\n(?= )/s', '', $actual );
 		$actual = preg_replace( '/^--+\n\n.*/ms', '', $actual );
 
 		$expectedFile = $file . '.expected';

--- a/Wikibase/Tests/WikibaseStandardTest.php
+++ b/Wikibase/Tests/WikibaseStandardTest.php
@@ -11,6 +11,9 @@ use SplFileInfo;
 /**
  * Test runner for custom Wikibase CodeSniffer sniffs. This is copied from the MediaWiki CodeSniffer
  * code repository, but simplified a lot.
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
  */
 class WikibaseStandardTest extends PHPUnit_Framework_TestCase {
 
@@ -45,12 +48,13 @@ class WikibaseStandardTest extends PHPUnit_Framework_TestCase {
 			'standard' => __DIR__ . '/..',
 			'sniffs' => [ $sniff ],
 			'files' => [ $file ],
-			'reportWidth' => 120,
+			'reportWidth' => 140,
 		];
 
 		ob_start();
 		$phpcs->process( $options );
 		$actual = ob_get_clean();
+
 		$actual = preg_replace( '/^.*--\n(?= )/s', '', $actual );
 		$actual = preg_replace( '/^--+\n\n.*/ms', '', $actual );
 

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,15 @@
 	"require": {
 		"php": ">=5.5.9",
 		"mediawiki/mediawiki-codesniffer": ">=0.7 <0.8"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "~4.8"
+	},
+	"scripts": {
+		"fix": "phpcbf",
+		"test": [
+			"phpcs -p -s",
+			"phpunit"
+		]
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="WikibaseCodeSniffer">
+	<rule ref="Wikibase" />
+
+	<rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+		<exclude-pattern>Wikibase/Sniffs/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+		<exclude-pattern>Wikibase/Sniffs/</exclude-pattern>
+	</rule>
+
+	<file>.</file>
+	<exclude-pattern>Tests/*/</exclude-pattern>
+</ruleset>

--- a/phpunit.bootstrap.php
+++ b/phpunit.bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ .'/vendor/autoload.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<phpunit bootstrap="./phpunit.bootstrap.php"
+		colors="true"
+		convertErrorsToExceptions="true"
+		convertNoticesToExceptions="true"
+		convertWarningsToExceptions="true">
+	<testsuites>
+		<testsuite name="WikibaseCodeSniffer">
+			<file>./Wikibase/Tests/WikibaseStandardTest.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>


### PR DESCRIPTION
Mostly meant as a baseline to be able to properly test custom sniffs.

Note these new sniffs must be disabled by default before doing a release!