### PR TITLE
[WIP] Add AlphabeticallyOrderedUseSniff

### DIFF
--- a/Wikibase/Sniffs/Namespaces/AlphabeticallyOrderedUseSniff.php
+++ b/Wikibase/Sniffs/Namespaces/AlphabeticallyOrderedUseSniff.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Custom sniff that checks if all "use" clauses are alphabetically ordered.
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
+ */
+class Wikibase_Sniffs_Namespaces_AlphabeticallyOrderedUseSniff implements PHP_CodeSniffer_Sniff {
+
+	public function register() {
+		return [ T_USE ];
+	}
+
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$nextPtr = $phpcsFile->findNext( T_USE, $stackPtr + 1 );
+		if ( !$nextPtr ) {
+			return;
+		}
+
+		$className1 = $this->getFullQualifiedClassName( $phpcsFile, $stackPtr + 1 );
+		$className2 = $this->getFullQualifiedClassName( $phpcsFile, $nextPtr + 1 );
+		if ( !$className1 || !$className2 || strcasecmp( $className1, $className2 ) < 0 ) {
+			return;
+		}
+
+		if ( $phpcsFile->addFixableError(
+			'Imports are not alphabetically ordered',
+			$nextPtr,
+			'Found'
+		) ) {
+			// TODO
+		}
+	}
+
+	/**
+	 * @param PHP_CodeSniffer_File $phpcsFile
+	 * @param int $usePtr
+	 *
+	 * @return string|null
+	 */
+	private function getFullQualifiedClassName( PHP_CodeSniffer_File $phpcsFile, $usePtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$className = '';
+
+		for ( $i = $usePtr; $i < $phpcsFile->numTokens; $i++ ) {
+			switch ( $tokens[$i]['code'] ) {
+				case T_AS:
+				case T_NS_SEPARATOR:
+				case T_STRING:
+				case T_WHITESPACE:
+					$className .= $tokens[$i]['content'];
+					break;
+				case T_SEMICOLON:
+					return $className;
+				default:
+					return null;
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/Wikibase/Tests/Namespaces/AlphabeticallyOrderedUse.php
+++ b/Wikibase/Tests/Namespaces/AlphabeticallyOrderedUse.php
@@ -1,0 +1,12 @@
+<?php
+
+use B;
+use C as A;
+use A;
+use Wikibase\IgnoreCapitalizationPlease;
+use Wikibase\Ignorecapitalization;
+
+function fn() use ( $var ) {
+}
+
+use IntentionallyBroken

--- a/Wikibase/Tests/Namespaces/AlphabeticallyOrderedUse.php.expected
+++ b/Wikibase/Tests/Namespaces/AlphabeticallyOrderedUse.php.expected
@@ -1,0 +1,2 @@
+ 5 | ERROR | [x] Imports are not alphabetically ordered
+ 7 | ERROR | [x] Imports are not alphabetically ordered


### PR DESCRIPTION
A run on the Wikibase.git code base currently shows ~400 violations.

This sniff is not meant to yell at patch uploaders when they did not put all `use` clauses in alphabetical order. That would be a burden. This is meant as an automatic fixup that is automatically done without any human interaction. It must be disabled by default and can not be part of the "Wikibase" standard. See #9 for a suggestion how to achieve this.

Currently the fixing part is missing.

Probably obsolete via https://github.com/slevomat/coding-standard.