### PR TITLE
Add two sniffs to find and remove unused "use" clauses

### DIFF
--- a/Wikibase/Sniffs/Namespaces/UnnecessaryUseSniff.php
+++ b/Wikibase/Sniffs/Namespaces/UnnecessaryUseSniff.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Custom sniff that checks and removes unnecessary "use" clauses that are in the same namespace as
+ * the rest of the code.
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
+ */
+class Wikibase_Sniffs_Namespaces_UnnecessaryUseSniff implements PHP_CodeSniffer_Sniff {
+
+	public function register() {
+		return [ T_USE ];
+	}
+
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		$nsPtr = $phpcsFile->findPrevious( T_NAMESPACE, $stackPtr - 1 );
+		if ( !$nsPtr ) {
+			// Shorten out as fast as possible if no "namespace" could be found
+			return;
+		}
+
+		$expectedUseEnd = $phpcsFile->numTokens - 1;
+		for ( $usePtr = $stackPtr + 1; ; $usePtr++ ) {
+			if ( $usePtr > $expectedUseEnd ) {
+				return;
+			}
+
+			$nsElement = $tokens[++$nsPtr];
+			$useElement = $tokens[$usePtr];
+
+			if ( $useElement['code'] === T_SEMICOLON ) {
+				if ( $usePtr === $expectedUseEnd
+					&& $tokens[$nsPtr - 2]['code'] === T_SEMICOLON
+					&& $tokens[$usePtr - 2]['code'] === T_NS_SEPARATOR
+				) {
+					// Successfully found a matching "use", continue after the loop
+					break;
+				}
+
+				// Shorten out if the "use" is shorter than expected
+				return;
+			}
+
+			if ( $nsElement['code'] !== $useElement['code']
+				|| trim( $nsElement['content'] ) !== trim( $useElement['content'] )
+			) {
+				// The "use" is expected to be 2 tokens longer than the "namespace"
+				$expectedUseEnd = min( $expectedUseEnd, $usePtr + 2 );
+			}
+		}
+
+		if ( !$phpcsFile->addFixableError(
+			'Unnecessary import identical to namespace',
+			$stackPtr,
+			'Found'
+		)
+		) {
+			return;
+		}
+
+		for ( $ptr = $stackPtr; $ptr <= $expectedUseEnd; $ptr++ ) {
+			$phpcsFile->fixer->replaceToken( $ptr, '' );
+		}
+		if ( $tokens[$ptr]['code'] === T_WHITESPACE && $tokens[$ptr]['content'][0] === "\n" ) {
+			// Remove only the one linebreak directly behind the removed "use"
+			$phpcsFile->fixer->substrToken( $ptr, 1 );
+		}
+	}
+
+}

--- a/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
+++ b/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Custom sniff that finds and removes "use" clauses that are neither used in code nor in
+ * documentation.
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
+ */
+class Wikibase_Sniffs_Namespaces_UnusedUseSniff implements PHP_CodeSniffer_Sniff {
+
+	public function register() {
+		return [ T_USE ];
+	}
+
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Shorten out if not on the top level, required to properly detect the use of traits
+		if ( !empty( $tokens[$stackPtr]['conditions'] ) ) {
+			return;
+		}
+
+		$useEndPtr = $phpcsFile->findEndOfStatement( $stackPtr + 1 );
+		$classNamePtr = $phpcsFile->findPrevious( T_STRING, $useEndPtr - 1, $stackPtr + 1 );
+		if ( !$classNamePtr ) {
+			return;
+		}
+
+		$className = $tokens[$classNamePtr]['content'];
+		$varDocPattern = '(\S+\s+)?\S*\b' . preg_quote( $className, '/' ) . '\b/i';
+
+		for ( $i = $useEndPtr + 1; $i < $phpcsFile->numTokens; $i++ ) {
+			$token = $tokens[$i];
+
+			if ( ( $token['code'] === T_STRING
+					&& strcasecmp( $token['content'], $className ) === 0
+				)
+				|| ( $token['code'] === T_DOC_COMMENT_TAG
+					&& preg_match( '/^@(expectedException|param|return|throw|type|var)/i', $token['content'] )
+					&& $tokens[$i + 2]['code'] === T_DOC_COMMENT_STRING
+					&& preg_match( '/^' . $varDocPattern, $tokens[$i + 2]['content'] )
+				)
+				|| ( $token['code'] === T_COMMENT
+					&& preg_match( '/@(type|var)\s+' . $varDocPattern, $token['content'] )
+				)
+			) {
+				return;
+			}
+		}
+
+		if ( !$phpcsFile->addFixableError( 'Unused import found', $stackPtr, 'Found' ) ) {
+			return;
+		}
+
+		for ( $ptr = $stackPtr; $ptr <= $useEndPtr; $ptr++ ) {
+			$phpcsFile->fixer->replaceToken( $ptr, '' );
+		}
+		if ( $tokens[$ptr]['code'] === T_WHITESPACE && $tokens[$ptr]['content'][0] === "\n" ) {
+			$phpcsFile->fixer->substrToken( $ptr, 1 );
+		}
+	}
+
+}

--- a/Wikibase/Tests/Namespaces/UnnecessaryUse.php
+++ b/Wikibase/Tests/Namespaces/UnnecessaryUse.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Wikibase\Own;
+
+use InMain;
+use Wikibase\Lower;
+use Wikibase\Own\Unnecessary;
+use Wikibase\Own\Deeper\Deeper;
+use Wikibase\Own\SameNamespace as ButRenamed;
+
+use InMain;use Wikibase\Own\Unnecessary; use InMain;
+
+use Wikibase\Own\Unnecessary;
+use Wikibase\Lower;
+use  Wikibase\Own\Unnecessary;
+use  Wikibase\Own;
+use Wikibase\Own/**/ ;
+
+class Example {
+}
+
+namespace Wikibase\Own \Sub {
+	use Wikibase\Own\Sub;
+}
+
+use Wikibase\Own\IntentionallyBroken

--- a/Wikibase/Tests/Namespaces/UnnecessaryUse.php.expected
+++ b/Wikibase/Tests/Namespaces/UnnecessaryUse.php.expected
@@ -1,0 +1,4 @@
+  7 | ERROR | [x] Unnecessary import identical to namespace
+ 11 | ERROR | [x] Unnecessary import identical to namespace
+ 13 | ERROR | [x] Unnecessary import identical to namespace
+ 15 | ERROR | [x] Unnecessary import identical to namespace

--- a/Wikibase/Tests/Namespaces/UnnecessaryUse.php.fixed
+++ b/Wikibase/Tests/Namespaces/UnnecessaryUse.php.fixed
@@ -1,0 +1,23 @@
+<?php
+
+namespace Wikibase\Own;
+
+use InMain;
+use Wikibase\Lower;
+use Wikibase\Own\Deeper\Deeper;
+use Wikibase\Own\SameNamespace as ButRenamed;
+
+use InMain; use InMain;
+
+use Wikibase\Lower;
+use  Wikibase\Own;
+use Wikibase\Own/**/ ;
+
+class Example {
+}
+
+namespace Wikibase\Own \Sub {
+	use Wikibase\Own\Sub;
+}
+
+use Wikibase\Own\IntentionallyBroken

--- a/Wikibase/Tests/Namespaces/UnusedUse.php
+++ b/Wikibase/Tests/Namespaces/UnusedUse.php
@@ -1,0 +1,63 @@
+<?php
+
+use Sub\Unused;
+use UsedButBadCapitalization;
+use Wikibase\AnotherBadCapitalization;
+use UnusedMain ;
+use UsedMain ;
+use AnotherUnusedMain;
+use Sub\Used;
+use Wikibase\Sub\UsedInAnArray;
+use UsedAndCommented;
+use MentionedInComment;
+use AppearsToBeUnused as ButIsUsed;
+use Sub\AnotherAlias as /* Comments should be skipped */WithAComment;
+use Sub\AndAnotherAlias as /** @note PHPDocs should also be skipped */WithADocComment;
+use UsedAfterParamName;
+use UsedAfterVarName;
+use UsedAfterPipe;
+use UsedTrait;
+use UsedExpectedException;
+use UsedThrows;
+use UsedReturn;
+
+/**
+ * @group Unused
+ */
+class Example implements UsedMain {
+
+	use UsedTrait;
+
+	/**
+	 * @type Used
+	 */
+	private $prop;
+
+	/**
+	 * @var UsedAndCommented with a comment
+	 */
+	private $prop;
+
+	/**
+	 * @var UsedButBadCapiTaliZation
+	 */
+	private $prop;
+
+	/**
+	 * @expectedException UsedExpectedException
+	 * @param int[]|UsedInAnArray[] $arg
+	 * @param bool $arg MentionedInComment should not count as usage
+	 * @param $arg UsedAfterParamName[]|null
+	 * @throws UsedThrows
+	 * @return UsedReturn
+	 */
+	private function process( array $arg, AnotherBadCapiTaliZation $arg ) {
+		/* @var ButIsUsed $var */
+		/* @var $var UsedAfterVarName[]|null */
+		/* @var $var null|UsedAfterPipe */
+		/* @var $var bool MentionedInComment should not count as usage */
+		$withAComment = new WithAComment();
+		$withADocComment = new WithADocComment();
+	}
+
+}

--- a/Wikibase/Tests/Namespaces/UnusedUse.php.expected
+++ b/Wikibase/Tests/Namespaces/UnusedUse.php.expected
@@ -1,0 +1,4 @@
+  3 | ERROR | [x] Unused import found
+  6 | ERROR | [x] Unused import found
+  8 | ERROR | [x] Unused import found
+ 12 | ERROR | [x] Unused import found

--- a/Wikibase/Tests/Namespaces/UnusedUse.php.fixed
+++ b/Wikibase/Tests/Namespaces/UnusedUse.php.fixed
@@ -1,0 +1,59 @@
+<?php
+
+use UsedButBadCapitalization;
+use Wikibase\AnotherBadCapitalization;
+use UsedMain ;
+use Sub\Used;
+use Wikibase\Sub\UsedInAnArray;
+use UsedAndCommented;
+use AppearsToBeUnused as ButIsUsed;
+use Sub\AnotherAlias as /* Comments should be skipped */WithAComment;
+use Sub\AndAnotherAlias as /** @note PHPDocs should also be skipped */WithADocComment;
+use UsedAfterParamName;
+use UsedAfterVarName;
+use UsedAfterPipe;
+use UsedTrait;
+use UsedExpectedException;
+use UsedThrows;
+use UsedReturn;
+
+/**
+ * @group Unused
+ */
+class Example implements UsedMain {
+
+	use UsedTrait;
+
+	/**
+	 * @type Used
+	 */
+	private $prop;
+
+	/**
+	 * @var UsedAndCommented with a comment
+	 */
+	private $prop;
+
+	/**
+	 * @var UsedButBadCapiTaliZation
+	 */
+	private $prop;
+
+	/**
+	 * @expectedException UsedExpectedException
+	 * @param int[]|UsedInAnArray[] $arg
+	 * @param bool $arg MentionedInComment should not count as usage
+	 * @param $arg UsedAfterParamName[]|null
+	 * @throws UsedThrows
+	 * @return UsedReturn
+	 */
+	private function process( array $arg, AnotherBadCapiTaliZation $arg ) {
+		/* @var ButIsUsed $var */
+		/* @var $var UsedAfterVarName[]|null */
+		/* @var $var null|UsedAfterPipe */
+		/* @var $var bool MentionedInComment should not count as usage */
+		$withAComment = new WithAComment();
+		$withADocComment = new WithADocComment();
+	}
+
+}


### PR DESCRIPTION
A run on the Wikibase.git code base currently shows 9 violations that are all fine and can be fixed automatically.

Note that the Wikibase.Namespaces.UnusedUse sniff does have a series of known as well as potential flaws:
* It considers class names aliased with `as`. The code to find the alias might be a bit naive and miss edge cases. However, I can not think of a test case that fails. Can you find one?
* It only considers a list of PHPDoc tags that are known to contain class names: `@expectedException`, `@param`, `@return`, `@throw`, and `@var` (as well as `@type` for compatibility, even if deprecated, see #8). Did I missed one?