### PR TITLE
Add InArrayUsage sniff

### DIFF
--- a/Wikibase/Sniffs/Usage/InArrayUsageSniff.php
+++ b/Wikibase/Sniffs/Usage/InArrayUsageSniff.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Custom sniff that finds unnecessary slow in_array() that can be replaced with array_key_exists()
+ * or isset().
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
+ */
+class Wikibase_Sniffs_Usage_InArrayUsageSniff implements PHP_CodeSniffer_Sniff {
+
+	public function register() {
+		return [ T_STRING ];
+	}
+
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		if ( strcasecmp( $tokens[$stackPtr]['content'], 'array_flip' ) !== 0
+			&& strcasecmp( $tokens[$stackPtr]['content'], 'array_keys' ) !== 0
+		) {
+			return;
+		}
+
+		// Continue only if the string we found is wrapped in at least one parenthesis
+		if ( empty( $tokens[$stackPtr]['nested_parenthesis'] ) ) {
+			return;
+		}
+
+		end( $tokens[$stackPtr]['nested_parenthesis'] );
+		$openParenthesisPtr = key( $tokens[$stackPtr]['nested_parenthesis'] );
+
+		// Continue only if the parenthesis belongs to an in_array() call
+		if ( $tokens[$openParenthesisPtr - 1]['code'] !== T_STRING
+			|| strcasecmp( $tokens[$openParenthesisPtr - 1]['content'], 'in_array' ) !== 0
+		) {
+			return;
+		}
+
+		$previous = $phpcsFile->findPrevious(
+			T_WHITESPACE,
+			$stackPtr - 1,
+			$openParenthesisPtr + 1,
+			true
+		);
+		if ( $tokens[$previous]['code'] !== T_COMMA ) {
+			return;
+		}
+
+		// TODO: Is it worth making this fixable?
+		$phpcsFile->addError(
+			'Found slow in_array( ' . $tokens[$stackPtr]['content']
+				. ' ), should be array_key_exists or isset',
+			$stackPtr,
+			'Found'
+		);
+	}
+
+}

--- a/Wikibase/Tests/Usage/InArrayUsage.php
+++ b/Wikibase/Tests/Usage/InArrayUsage.php
@@ -1,0 +1,17 @@
+<?php
+
+// Should use array_key_exists
+in_array( $key, array_keys( $array ) );
+in_array( $key, array_flip( $array ) );
+in_array( $key, array_keys );
+
+// Nothing wrong with these
+in_array( $key, $array );
+array_keys( $array );
+array_key_exists( $key, $array );
+in_array( $key ) && array_keys( $array );
+in_array( array_keys( $key ), $array );
+
+// Nested parenthesis
+if ( !in_array( $key, array_keys( $array ) ) ) {
+}

--- a/Wikibase/Tests/Usage/InArrayUsage.php.expected
+++ b/Wikibase/Tests/Usage/InArrayUsage.php.expected
@@ -1,0 +1,4 @@
+  4 | ERROR | Found slow in_array( array_keys ), should be array_key_exists or isset
+  5 | ERROR | Found slow in_array( array_flip ), should be array_key_exists or isset
+  6 | ERROR | Found slow in_array( array_keys ), should be array_key_exists or isset
+ 16 | ERROR | Found slow in_array( array_keys ), should be array_key_exists or isset


### PR DESCRIPTION
Custom sniff that finds unnecessary slow in_array() that can be replaced with array_key_exists() or isset().

Pinging @legoktm as he might be interested.