### PR TITLE
Update used PHPCS version to 3.0.x

### DIFF
--- a/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
+++ b/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace Wikibase\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
 /**
  * Custom sniff that reports classes, interfaces, and traits that are not directly preceded by a
  * non-empty documentation comment. Comments with empty PHPDoc tags like "@inheritDoc" are still
@@ -10,7 +15,7 @@
  * @license GPL-2.0+
  * @author Thiemo Kreuz
  */
-class Wikibase_Sniffs_Commenting_ClassLevelDocumentationSniff implements PHP_CodeSniffer_Sniff {
+class ClassLevelDocumentationSniff implements Sniff {
 
 	public function register() {
 		return [
@@ -20,7 +25,7 @@ class Wikibase_Sniffs_Commenting_ClassLevelDocumentationSniff implements PHP_Cod
 		];
 	}
 
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 		$previous = $phpcsFile->findPrevious( [
 			T_ABSTRACT,

--- a/Wikibase/Sniffs/Commenting/DisallowedDocTagsSniff.php
+++ b/Wikibase/Sniffs/Commenting/DisallowedDocTagsSniff.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace Wikibase\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
 /**
  * Custom sniff that reports deprecated PHPDoc tags (e.g. known misspellings) and replaces them with
  * their preferred counterparts.
@@ -9,7 +14,7 @@
  * @license GPL-2.0+
  * @author Thiemo Kreuz
  */
-class Wikibase_Sniffs_Commenting_DisallowedDocTagsSniff implements PHP_CodeSniffer_Sniff {
+class DisallowedDocTagsSniff implements Sniff {
 
 	/**
 	 * @var array Array mapping deprecated to preferred PHPDoc tags. If an array key is all
@@ -38,7 +43,7 @@ class Wikibase_Sniffs_Commenting_DisallowedDocTagsSniff implements PHP_CodeSniff
 		return [ T_DOC_COMMENT_TAG ];
 	}
 
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tag = $phpcsFile->getTokensAsString( $stackPtr, 1 );
 		$replacement = false;
 

--- a/Wikibase/Sniffs/Commenting/RedundantVarNameSniff.php
+++ b/Wikibase/Sniffs/Commenting/RedundantVarNameSniff.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace Wikibase\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
 /**
  * Custom sniff that reports and repairs "@var" documentations of class properties that repeat the
  * variable name, which is unnecessary.
@@ -9,13 +14,13 @@
  * @license GPL-2.0+
  * @author Thiemo Kreuz
  */
-class Wikibase_Sniffs_Commenting_RedundantVarNameSniff implements PHP_CodeSniffer_Sniff {
+class RedundantVarNameSniff implements Sniff {
 
 	public function register() {
 		return [ T_DOC_COMMENT_TAG ];
 	}
 
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
 		if ( strtolower( $tokens[$stackPtr]['content'] ) !== '@var' ) {

--- a/Wikibase/Sniffs/Namespaces/UnnecessaryUseSniff.php
+++ b/Wikibase/Sniffs/Namespaces/UnnecessaryUseSniff.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace Wikibase\Sniffs\Namespaces;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
 /**
  * Custom sniff that checks and removes unnecessary "use" clauses that are in the same namespace as
  * the rest of the code.
@@ -9,13 +14,13 @@
  * @license GPL-2.0+
  * @author Thiemo Kreuz
  */
-class Wikibase_Sniffs_Namespaces_UnnecessaryUseSniff implements PHP_CodeSniffer_Sniff {
+class UnnecessaryUseSniff implements Sniff {
 
 	public function register() {
 		return [ T_USE ];
 	}
 
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
 		$nsPtr = $phpcsFile->findPrevious( T_NAMESPACE, $stackPtr - 1 );

--- a/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
+++ b/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace Wikibase\Sniffs\Namespaces;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
 /**
  * Custom sniff that finds and removes "use" clauses that are neither used in code nor in
  * documentation.
@@ -9,13 +14,13 @@
  * @license GPL-2.0+
  * @author Thiemo Kreuz
  */
-class Wikibase_Sniffs_Namespaces_UnusedUseSniff implements PHP_CodeSniffer_Sniff {
+class UnusedUseSniff implements Sniff {
 
 	public function register() {
 		return [ T_USE ];
 	}
 
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
 		// Shorten out if not on the top level, required to properly detect the use of traits

--- a/Wikibase/Sniffs/Usage/InArrayUsageSniff.php
+++ b/Wikibase/Sniffs/Usage/InArrayUsageSniff.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace Wikibase\Sniffs\Usage;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
 /**
  * Custom sniff that finds unnecessary slow in_array() that can be replaced with array_key_exists()
  * or isset().
@@ -9,13 +14,13 @@
  * @license GPL-2.0+
  * @author Thiemo Kreuz
  */
-class Wikibase_Sniffs_Usage_InArrayUsageSniff implements PHP_CodeSniffer_Sniff {
+class InArrayUsageSniff implements Sniff {
 
 	public function register() {
 		return [ T_STRING ];
 	}
 
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
 		if ( strcasecmp( $tokens[$stackPtr]['content'], 'array_flip' ) !== 0

--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -18,12 +18,16 @@
 		<exclude name="MediaWiki.Commenting.FunctionComment" />
 
 		<!-- We disagree with the idea of certain characters making comments "illegal" and blocking
-			patches from being merged. This behaves especially bad on commented out code. -->
+			patches from being merged. This behaves especially bad on code examples. -->
 		<exclude name="MediaWiki.Commenting.IllegalSingleLineComment" />
 
 		<!-- Starting a function's body with an empty line can be helpful after a very large header.
 			The code is not guaranteed to be easier to read if this is disallowed. -->
 		<exclude name="MediaWiki.WhiteSpace.DisallowEmptyLineFunctions" />
+
+		<!-- Even if we encourage to use a space in "function ()", we don't think this sniff should
+			block patches from being merged. -->
+		<exclude name="MediaWiki.WhiteSpace.SpaceAfterClosure" />
 
 		<!-- Even if we encourage to use spaces in comments, we don't think this sniff should block
 			patches from being merged. -->
@@ -52,8 +56,6 @@
 	<!-- NOTE: Never add the Generic.Metrics.… sniffs to this generic rule set, because these are
 		not about "code style", and the exact limits are highly disputable. -->
 
-	<rule ref="Generic.PHP.CharacterBeforePHPOpeningTag" />
-
 	<rule ref="MediaWiki.NamingConventions.LowerCamelFunctionsName">
 		<!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
 		<exclude-pattern>tests*Test*\.php</exclude-pattern>
@@ -70,9 +72,8 @@
 		<exclude-pattern>tests*Test*\.php</exclude-pattern>
 	</rule>
 
-	<!-- Disallows ?> and enforces a single blank line at the end of the file. See
-		http://www.php-fig.org/psr/psr-2/#files -->
-	<rule ref="PSR2.Files" />
+	<!-- Disallows ?>. See http://www.php-fig.org/psr/psr-2/#files -->
+	<rule ref="PSR2.Files.ClosingTag" />
 
 	<!-- NOTE: We can not use the Squiz.Arrays.ArrayBracketSpacing sniff because it conflicts with
 		the MediaWiki style that encourages to use spaces inside brackets, see
@@ -104,9 +105,6 @@
 			<property name="spacing" value="1" />
 		</properties>
 	</rule>
-
-	<!-- Disallows the use of AND and OR in favor of && and ||. -->
-	<rule ref="Squiz.Operators.ValidLogicalOperators" />
 
 	<!-- Makes sure operators are surrounded by spaces. This includes comparisons, assignments, and
 		calculations like 1 / 60. -->

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"require": {
 		"php": ">=5.5.9",
-		"mediawiki/mediawiki-codesniffer": "0.8.1"
+		"mediawiki/mediawiki-codesniffer": "0.9.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8"

--- a/phpunit.bootstrap.php
+++ b/phpunit.bootstrap.php
@@ -1,3 +1,15 @@
 <?php
 
-require_once __DIR__ .'/vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/vendor/squizlabs/php_codesniffer/autoload.php';
+
+// Trigger autoload of tokens
+new PHP_CodeSniffer\Util\Tokens();
+
+if ( !defined( 'PHP_CODESNIFFER_CBF' ) ) {
+	define( 'PHP_CODESNIFFER_CBF', false );
+}
+
+if ( !defined( 'PHP_CODESNIFFER_VERBOSITY' ) ) {
+	define( 'PHP_CODESNIFFER_VERBOSITY', false );
+}


### PR DESCRIPTION
This updates the underlying MediaWiki component from 0.8.x to 0.9.x, which updates PHPCS itself from 2.x to 3.x. The major update was needed on the WikibaseStandardTest test runner, which luckily turned out to be much more trivial than I expected.

This pull request is meant to be a purely technical update. I made sure this patch does not change the list of active sniffs. The only new addition from the MediaWiki rule set is the SpaceAfterClosure sniff, which I turned off for the moment. This is to be discussed in later patches and release candidates.