### PR TITLE
Update the used MediaWiki rule set to 0.10.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,13 @@
 # Wikibase CodeSniffer standards changelog
 
+## 0.3.0 (dev)
+
+* Updated the base MediaWiki rule set from 0.8 to 0.10.1. This adds the following sniffs:
+	* `Generic.PHP.BacktickOperator`
+	* `MediaWiki.AlternativeSyntax.PHP7UnicodeSyntax`
+	* `MediaWiki.AlternativeSyntax.ShortCastSyntax`
+	* `MediaWiki.Usage.ReferenceThis`
+
 ## 0.2.0 (2017-10-13)
 
 * Added custom sniffs:

--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -79,9 +79,6 @@
 		the MediaWiki style that encourages to use spaces inside brackets, see
 		https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript#Whitespace -->
 
-	<!-- Makes sure self::… is used instead of repeating the class name. -->
-	<rule ref="Squiz.Classes.SelfMemberReference" />
-
 	<!-- Makes sure control structures like if ( … ), for ( …; …; … ) etc. properly use spaces. -->
 	<rule ref="Squiz.ControlStructures.ControlSignature" />
 
@@ -117,8 +114,5 @@
 
 	<arg name="extensions" value="php" />
 	<arg name="encoding" value="UTF-8" />
-	<exclude-pattern type="relative">^\.git</exclude-pattern>
 	<exclude-pattern type="relative">^extensions/</exclude-pattern>
-	<exclude-pattern type="relative">^node_modules/</exclude-pattern>
-	<exclude-pattern type="relative">^vendor/</exclude-pattern>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"require": {
 		"php": ">=5.5.9",
-		"mediawiki/mediawiki-codesniffer": "0.9.0"
+		"mediawiki/mediawiki-codesniffer": "0.10.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8"


### PR DESCRIPTION
I carefully reviewed the new sniffs that come with this version, and I believe they are fine:
* Backtick operators, short casts, and `&$this` references don't even exist in our code bases, and should not, so these additions are fine.
* We obviously need to allow PHP 7 syntax later when we finally dropped PHP 5 support. But this will take a while and should be done via separate releases. For the moment I suggest to stick to what the MediaWiki rule set does, and not opt-out of this sniff.

**Warning**,  #16 should be merged first!