### PR TITLE
Update the used MediaWiki rule set to 0.11.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,11 +2,13 @@
 
 ## 0.3.0 (dev)
 
-* Updated the base MediaWiki rule set from 0.8 to 0.10.1. This adds the following sniffs:
+* Updated the base MediaWiki rule set from 0.8 to 0.11.1. This adds the following sniffs:
 	* `Generic.PHP.BacktickOperator`
 	* `MediaWiki.AlternativeSyntax.PHP7UnicodeSyntax`
 	* `MediaWiki.AlternativeSyntax.ShortCastSyntax`
 	* `MediaWiki.Usage.ReferenceThis`
+	* `MediaWiki.Usage.ScalarTypeHintUsage`
+	* `MediaWiki.WhiteSpace.OpeningKeywordBrace`
 
 ## 0.2.0 (2017-10-13)
 

--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -103,15 +103,6 @@
 		</properties>
 	</rule>
 
-	<!-- Makes sure operators are surrounded by spaces. This includes comparisons, assignments, and
-		calculations like 1 / 60. -->
-	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
-		<properties>
-			<!-- But we need to allow splitting long lines. -->
-			<property name="ignoreNewlines" value="true" />
-		</properties>
-	</rule>
-
 	<arg name="extensions" value="php" />
 	<arg name="encoding" value="UTF-8" />
 	<exclude-pattern type="relative">^extensions/</exclude-pattern>

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"require": {
 		"php": ">=5.5.9",
-		"mediawiki/mediawiki-codesniffer": "0.10.1"
+		"mediawiki/mediawiki-codesniffer": "0.11.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8"


### PR DESCRIPTION
I carefully reviewed the new sniffs that come with this version and found both acceptable:
* Scalar type hints are an other PHP 7 feature that will temporarily be forbidden, until we actually dropped PHP 5 support. As argued before in #17 I don't have a personal opinion on this. We could also disable this here.
* Language features that are used like they are functions are not allowed to have spaces, e.g. `empty ()` is forbidden. I believe this is what everybody does anyway.

**Warning**, this is a chain of patches! #16 and #17 should be merged first.