### PR TITLE
Update the used MediaWiki rule set to 0.12.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,13 +2,16 @@
 
 ## 0.3.0 (dev)
 
-* Updated the base MediaWiki rule set from 0.8 to 0.11.1. This adds the following sniffs:
+* Updated the base MediaWiki rule set from 0.8 to 0.12.0. This adds the following sniffs:
 	* `Generic.PHP.BacktickOperator`
+	* `MediaWiki.AlternativeSyntax.LeadingZeroInFloat`
 	* `MediaWiki.AlternativeSyntax.PHP7UnicodeSyntax`
 	* `MediaWiki.AlternativeSyntax.ShortCastSyntax`
+	* `MediaWiki.Files.ClassMatchesFilename`
+	* `MediaWiki.Files.OneClassPerFile`
 	* `MediaWiki.Usage.ReferenceThis`
 	* `MediaWiki.Usage.ScalarTypeHintUsage`
-	* `MediaWiki.WhiteSpace.OpeningKeywordBrace`
+	* `MediaWiki.WhiteSpace.OpeningKeywordParenthesis`
 
 ## 0.2.0 (2017-10-13)
 

--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -49,10 +49,6 @@
 		<exclude-pattern>\.i18n\.magic\.php</exclude-pattern>
 	</rule>
 
-	<rule ref="Generic.Files.OneClassPerFile" />
-	<rule ref="Generic.Files.OneInterfacePerFile" />
-	<rule ref="Generic.Files.OneTraitPerFile" />
-
 	<!-- NOTE: Never add the Generic.Metrics.… sniffs to this generic rule set, because these are
 		not about "code style", and the exact limits are highly disputable. -->
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"require": {
 		"php": ">=5.5.9",
-		"mediawiki/mediawiki-codesniffer": "0.11.1"
+		"mediawiki/mediawiki-codesniffer": "0.12.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8"


### PR DESCRIPTION
I reviewed the new sniffs that come with this update and believe they are all fine. But feel free to disagree, and briefly explain your reasoning. Better disable one or two disputed sniffs than not updating, because all these updates also come with bugfixes.
* LeadingZeroInFloat is not terribly important, but I think `0.1` is better readably than `.1` and worth a sniff.
* ClassMatchesFilename is obvious, I hope.
* The new OneClassPerFile sniff does have a confusing name. It checks for classes, interfaces, and traits in one step and does not only replace the three individual sniffs, it does more that these: the individual sniffs are not able to detect cases with, for example, an interface and a class in one file.
* OpeningKeywordBrace just got renamed.

**Warning**, this is a chain of patches! #16, #17, and #18 should be merged first!