### PR TITLE
Update the used MediaWiki rule set to 13.0.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,15 +2,17 @@
 
 ## 0.3.0 (dev)
 
-* Updated the base MediaWiki rule set from 0.8 to 0.12.0. This adds the following sniffs:
+* Updated the base MediaWiki rule set from 0.8 to 13.0.0. This adds the following sniffs:
 	* `Generic.PHP.BacktickOperator`
 	* `MediaWiki.AlternativeSyntax.LeadingZeroInFloat`
 	* `MediaWiki.AlternativeSyntax.PHP7UnicodeSyntax`
 	* `MediaWiki.AlternativeSyntax.ShortCastSyntax`
 	* `MediaWiki.Files.ClassMatchesFilename`
 	* `MediaWiki.Files.OneClassPerFile`
+	* `MediaWiki.Usage.DeprecatedConstantUsage`
 	* `MediaWiki.Usage.ReferenceThis`
 	* `MediaWiki.Usage.ScalarTypeHintUsage`
+	* `MediaWiki.VariableAnalysis.ForbiddenGlobalVariables`
 	* `MediaWiki.WhiteSpace.OpeningKeywordParenthesis`
 
 ## 0.2.0 (2017-10-13)

--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -4,6 +4,9 @@
 		https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml
 		-->
 	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<!-- Temporarily disabled, might replace Wikibase.Namespaces.UnusedUse. -->
+		<exclude name="MediaWiki.Classes.UnusedUseStatement" />
+
 		<!-- The function comment sniff is way to rigorous about way to many details that need
 			exceptions:
 			* It complains when "@param <type> $<var>" is not followed by a comment, even if type

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"require": {
 		"php": ">=5.5.9",
-		"mediawiki/mediawiki-codesniffer": "0.12.0"
+		"mediawiki/mediawiki-codesniffer": "13.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8"


### PR DESCRIPTION
I'm postponing the decision for the "unused use statements" sniff for the moment because I would like to test this more carefully, and possibly update the sniff upstream in the MediaWiki rule set. This should not block this update from happening.

The two new sniffs only check for some very, very specific deprecated MediaWiki constants and globals. We don't use these in our code bases, and shouldn't.

**Warning**, this is a chain of patches! #16, #17, #18, and #19 should be merged first!