### PR TITLE
Disallow obsolete PHPDoc tag @package

### DIFF
--- a/Wikibase/Sniffs/Commenting/DisallowedDocTagsSniff.php
+++ b/Wikibase/Sniffs/Commenting/DisallowedDocTagsSniff.php
@@ -32,6 +32,9 @@ class Wikibase_Sniffs_Commenting_DisallowedDocTagsSniff implements PHP_CodeSniff
 		// https://phpunit.de/manual/current/en/appendixes.annotations.html#appendixes.annotations.covers
 		'@cover' => '@covers',
 		'@use' => '@uses',
+
+		// https://github.com/slevomat/coding-standard#slevomatcodingstandardcommentingforbiddenannotations-
+		'@package' => null,
 	];
 
 	public function register() {

--- a/Wikibase/Tests/Commenting/DisallowedDocTags.php
+++ b/Wikibase/Tests/Commenting/DisallowedDocTags.php
@@ -63,3 +63,9 @@ function upperCaseTags() {
  */
 function notADocComment() {
 }
+
+/**
+ * @package Obsolete
+ */
+function disallowedTags() {
+}

--- a/Wikibase/Tests/Commenting/DisallowedDocTags.php.expected
+++ b/Wikibase/Tests/Commenting/DisallowedDocTags.php.expected
@@ -14,3 +14,4 @@
  45 | ERROR | [x] Found @Throw instead of @throws
  46 | ERROR | [x] Found @Type instead of @var
  47 | ERROR | [x] Found @Use instead of @uses
+ 68 | ERROR | [ ] PHPDoc tag @package is not allowed

--- a/Wikibase/Tests/Commenting/DisallowedDocTags.php.fixed
+++ b/Wikibase/Tests/Commenting/DisallowedDocTags.php.fixed
@@ -63,3 +63,9 @@ function upperCaseTags() {
  */
 function notADocComment() {
 }
+
+/**
+ * @package Obsolete
+ */
+function disallowedTags() {
+}


### PR DESCRIPTION
This tag was introduced when PHP had no namespaces. Now that we use namespaces is does not add anything.

Fixes #15.