### PR TITLE
Fix accidential code smell in test code

### DIFF
--- a/Wikibase/Tests/Namespaces/UnusedUse.php
+++ b/Wikibase/Tests/Namespaces/UnusedUse.php
@@ -36,12 +36,12 @@ class Example implements UsedMain {
 	/**
 	 * @var UsedAndCommented with a comment
 	 */
-	private $prop;
+	private $prop2;
 
 	/**
 	 * @var UsedButBadCapiTaliZation
 	 */
-	private $prop;
+	private $prop3;
 
 	/**
 	 * @expectedException UsedExpectedException

--- a/Wikibase/Tests/Namespaces/UnusedUse.php.fixed
+++ b/Wikibase/Tests/Namespaces/UnusedUse.php.fixed
@@ -32,12 +32,12 @@ class Example implements UsedMain {
 	/**
 	 * @var UsedAndCommented with a comment
 	 */
-	private $prop;
+	private $prop2;
 
 	/**
 	 * @var UsedButBadCapiTaliZation
 	 */
-	private $prop;
+	private $prop3;
 
 	/**
 	 * @expectedException UsedExpectedException


### PR DESCRIPTION
My PHPStorm keeps highlighting entire directories as containing a critical code smell because of this. But the duplicate class properties are irrelevant for what this sniff is meant to do.