### PR TITLE
Update to MediaWiki CodeSniffer version 16.0.0

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="WikibaseCodeSniffer">
+<ruleset>
 	<rule ref="Wikibase" />
-
-	<rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
-		<exclude-pattern>Wikibase/Sniffs/</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
-		<exclude-pattern>Wikibase/Sniffs/</exclude-pattern>
-	</rule>
 
 	<file>.</file>
 	<exclude-pattern>Tests/*/</exclude-pattern>

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,8 +1,13 @@
 # Wikibase CodeSniffer standards changelog
 
+## 0.4.0 (dev)
+
+* Updated the base MediaWiki rule set from 15.x to 16.0.0. This adds the following sniffs:
+	* `MediaWiki.Usage.AssignmentInReturn`
+
 ## 0.3.0 (2018-02-12)
 
-* Updated the base MediaWiki rule set from 0.8 to 15.0.0. This adds the following sniffs:
+* Updated the base MediaWiki rule set from 0.8.x to 15.0.0. This adds the following sniffs:
 	* `Generic.Files.OneObjectStructurePerFile` (replaces `Generic.Files.OneClass…`, `…Interface…`,
 	  and `…TraitPerFile`)
 	* `Generic.PHP.BacktickOperator`
@@ -28,7 +33,7 @@
 	* `Wikibase.Namespaces.UnnecessaryUse`
 	* `Wikibase.Namespaces.UnusedUse`
 	* `Wikibase.Usage.InArrayUsage`
-* Updated the base MediaWiki rule set from 0.7 to 0.8.1. This adds the following sniffs:
+* Updated the base MediaWiki rule set from 0.7.x to 0.8.1. This adds the following sniffs:
 	* `Generic.Formatting.NoSpaceAfterCast`
 	* `MediaWiki.ExtraCharacters.ParenthesesAroundKeyword`
 	* `MediaWiki.NamingConventions.LowerCamelFunctionsName`

--- a/Wikibase/Tests/WikibaseStandardTest.php
+++ b/Wikibase/Tests/WikibaseStandardTest.php
@@ -7,7 +7,7 @@ use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Reporter;
 use PHP_CodeSniffer\Ruleset;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
@@ -19,7 +19,7 @@ use SplFileInfo;
  * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
-class WikibaseStandardTest extends PHPUnit_Framework_TestCase {
+class WikibaseStandardTest extends TestCase {
 
 	public static function provideTestCases() {
 		$tests = [];

--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -25,6 +25,14 @@
 			patches from being merged. This behaves especially bad on code examples. -->
 		<exclude name="MediaWiki.Commenting.IllegalSingleLineComment" />
 
+		<!-- Temporary disabled because it erroneously reports missing @covers tags on abstract base
+			classes. -->
+		<exclude name="MediaWiki.Commenting.MissingCovers" />
+
+		<!-- Individual projects should be free to decide if they want to wait for PHPUnit 6, or
+			start using namespaced class names in advance. -->
+		<exclude name="MediaWiki.Usage.PHPUnitClassUsage" />
+
 		<!-- Starting a function's body with an empty line can be helpful after a very large header.
 			The code is not guaranteed to be easier to read if this is disallowed. -->
 		<exclude name="MediaWiki.WhiteSpace.DisallowEmptyLineFunctions" />

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,17 @@
 	],
 	"require": {
 		"php": ">=5.5.9",
-		"mediawiki/mediawiki-codesniffer": "15.0.0"
+		"mediawiki/mediawiki-codesniffer": "16.0.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~4.8"
+		"phpunit/phpunit": "^4.8.35"
 	},
 	"scripts": {
-		"fix": "phpcbf",
 		"test": [
 			"composer validate --no-interaction",
 			"phpcs -p -s",
 			"phpunit"
-		]
+		],
+		"fix": "phpcbf"
 	}
 }


### PR DESCRIPTION
This patch also includes some minor cleanups:
* Remove exceptions from local .phpcs.xml we forgot to remove in #16.
* Use forwards-compatible TestCase alias.
* Move "fix" to the bottom.