### PR TITLE
Add sniff that disallows full qualified class names

### DIFF
--- a/Wikibase/Sniffs/Namespaces/FullQualifiedClassNameSniff.php
+++ b/Wikibase/Sniffs/Namespaces/FullQualifiedClassNameSniff.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Wikibase\Sniffs\Namespaces;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Custom sniff that disallows full qualified class names outside of the "use" section.
+ *
+ * Class names in the main namespace (e.g. "\Title") are intentionally allowed for several reasons:
+ * - The class name is still recognizable with a single backslash in front.
+ * - A "use" takes more space than a dozen backslashes.
+ * - This reflects the actual living code style in the Wikibase code bases that contain hundreds of
+ *   "\MediaWikiTestCase", "\InvalidArgumentException", "\FauxRequest", and such.
+ *
+ * This sniff currently does not check class names mentioned in PHPDoc comments.
+ *
+ * @since 0.4.0
+ *
+ * @license GPL-2.0-or-later
+ * @author Thiemo Kreuz
+ */
+class FullQualifiedClassNameSniff implements Sniff {
+
+	public function register() {
+		return [ T_NS_SEPARATOR ];
+	}
+
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Shorten out if:
+		// - There is no namespace before the backslash. This intentionally allows "\Bar".
+		// - There is no class name after the backslash.
+		// - This backslash is not the last one before the class name.
+		// - We are not dealing with a class name but a function.
+		if ( $tokens[$stackPtr - 1]['code'] !== T_STRING
+			|| $tokens[$stackPtr + 1]['code'] !== T_STRING
+			|| $tokens[$stackPtr + 2]['code'] === T_NS_SEPARATOR
+			|| $tokens[$stackPtr + 2]['code'] === T_OPEN_PARENTHESIS
+		) {
+			return;
+		}
+
+		$prev = $phpcsFile->findStartOfStatement( $stackPtr - 1 );
+		if ( $tokens[$prev]['code'] === T_NAMESPACE
+			|| $tokens[$prev]['code'] === T_USE
+		) {
+			return;
+		}
+
+		$phpcsFile->addError(
+			'Full qualified class name "…\\%s" found, please utilize "use"',
+			$stackPtr,
+			'Found',
+			[ $tokens[$stackPtr + 1]['content'] ]
+		);
+	}
+
+}

--- a/Wikibase/Tests/Namespaces/FullQualifiedClassName.php
+++ b/Wikibase/Tests/Namespaces/FullQualifiedClassName.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OwnNamespace\Deeper;
+
+use SomeNamespace\Example1;
+use /* Comment */ /** @inheritDoc */ SomeNamespace\Deeper\Example2;
+use \SomeNamespace\Example3 as Example4;
+
+/**
+ * @covers \SomeNamespace\Example1
+ */
+class AllowSingleBackslash extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @param Example1 $a
+	 * @param SomeNamespace\Example1 $b Class names in PHPDoc comments are currently not checked.
+	 * @return \SomeNamespace\Example1
+	 */
+	public function allowFunctions() {
+		\Wikimedia\suppressWarnings();
+	}
+
+}
+
+class AllowClassNameOnly extends Example4 {
+}
+
+class DisallowedFullQualifiedClassName extends SomeNamespace\Example1 {
+}
+
+class DisallowedFullQualifiedClassNameWithBackslash extends \SomeNamespace\Example1 {
+}

--- a/Wikibase/Tests/Namespaces/FullQualifiedClassName.php.expected
+++ b/Wikibase/Tests/Namespaces/FullQualifiedClassName.php.expected
@@ -1,0 +1,2 @@
+ 28 | ERROR | Full qualified class name "…\Example1" found, please utilize "use"
+ 31 | ERROR | Full qualified class name "…\Example1" found, please utilize "use"


### PR DESCRIPTION
I checked with the Wikibase code base, and there are almost literally zero exceptions. The only exceptions are in the repo/Wikibase.php entry point (that is not a class), and in some classes for the CirrusSearch integration written by WMF staff. What this means is: The Wikidata team already follows this code style rule. We just never had a sniff for this, because there is no pre-defined one we could use.

I suggest to add this as a strict rule. This will help in discussions like the most recent one in https://gerrit.wikimedia.org/r/#/c/413731/1/tests/phpunit/includes/BeforePageDisplayHookHandlerTest.php.