### PR TITLE
Release 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ How to install
     ```
     {
     	"require-dev": {
-    		"wikibase/wikibase-codesniffer": "^0.3.0"
+    		"wikibase/wikibase-codesniffer": "^0.4.0"
     	},
     	"scripts": {
     		"test": [

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,13 +1,16 @@
 # Wikibase CodeSniffer standards changelog
 
-## 0.4.0 (dev)
+## 0.4.0 (2018-03-06)
 
-* Updated the base MediaWiki rule set from 15.x to 16.0.0. This adds the following sniffs:
+* Added custom `Wikibase.Namespaces.FullQualifiedClassName` sniff.
+* Updated the base MediaWiki rule set from 15.0.0 to 16.0.1. This adds the following sniff:
 	* `MediaWiki.Usage.AssignmentInReturn`
+* Removed `PSR1.Methods.CamelCapsMethodName` (redundant to
+  `MediaWiki.NamingConventions.LowerCamelFunctionsName`).
 
 ## 0.3.0 (2018-02-12)
 
-* Updated the base MediaWiki rule set from 0.8.x to 15.0.0. This adds the following sniffs:
+* Updated the base MediaWiki rule set from 0.8.1 to 15.0.0. This adds the following sniffs:
 	* `Generic.Files.OneObjectStructurePerFile` (replaces `Generic.Files.OneClass…`, `…Interface…`,
 	  and `…TraitPerFile`)
 	* `Generic.PHP.BacktickOperator`

--- a/Wikibase/Sniffs/Namespaces/FullQualifiedClassNameSniff.php
+++ b/Wikibase/Sniffs/Namespaces/FullQualifiedClassNameSniff.php
@@ -9,7 +9,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  * Custom sniff that disallows full qualified class names outside of the "use" section.
  *
  * Class names in the main namespace (e.g. "\Title") are intentionally allowed for several reasons:
- * - The class name is still recognizable with a single backslash in front.
+ * - The class name is still easily recognizable with the single backslash in front.
  * - A "use" takes more space than a dozen backslashes.
  * - This reflects the actual living code style in the Wikibase code bases that contain hundreds of
  *   "\MediaWikiTestCase", "\InvalidArgumentException", "\FauxRequest", and such.

--- a/Wikibase/Sniffs/Usage/InArrayUsageSniff.php
+++ b/Wikibase/Sniffs/Usage/InArrayUsageSniff.php
@@ -54,7 +54,6 @@ class InArrayUsageSniff implements Sniff {
 			return;
 		}
 
-		// TODO: Is it worth making this fixable?
 		$phpcsFile->addError(
 			'Found slow in_array( ' . $tokens[$stackPtr]['content']
 				. ' ), should be array_key_exists or isset',

--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -69,17 +69,6 @@
 		<exclude-pattern>tests*Test*\.php</exclude-pattern>
 	</rule>
 
-	<!-- See http://www.php-fig.org/psr/psr-1/ -->
-	<rule ref="PSR1">
-		<!-- Entry points typically have side effects, which is why this sniff is a "should" and not
-			a "must" in PSR-1. -->
-		<exclude name="PSR1.Files.SideEffects" />
-	</rule>
-	<rule ref="PSR1.Methods.CamelCapsMethodName">
-		<!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
-		<exclude-pattern>tests*Test*\.php</exclude-pattern>
-	</rule>
-
 	<!-- Disallows ?>. See http://www.php-fig.org/psr/psr-2/#files -->
 	<rule ref="PSR2.Files.ClosingTag" />
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"require": {
 		"php": ">=5.5.9",
-		"mediawiki/mediawiki-codesniffer": "16.0.0"
+		"mediawiki/mediawiki-codesniffer": "16.0.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^4.8.35"


### PR DESCRIPTION
PSR1 is made of only 3 sniffs:
* The ClassDeclaration one is still pulled in via the MediaWiki rule set.
* The SideEffects one was disabled anyway, and still is.
* The CamelCapsMethodName was always redundant, and was never part of the MediaWiki rule set.

The "0.7.x" in the release notes is intentional, because this really was the way this dependency was specified back then.