### PR TITLE
Allow full qualified \PHPUnit\Framework\TestCase

### DIFF
--- a/Wikibase/Sniffs/Namespaces/FullQualifiedClassNameSniff.php
+++ b/Wikibase/Sniffs/Namespaces/FullQualifiedClassNameSniff.php
@@ -6,11 +6,11 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
- * Custom sniff that disallows full qualified class names outside of the "use" section.
+ * Custom sniff that disallows full qualified class names outside of the "use …" section.
  *
  * Class names in the main namespace (e.g. "\Title") are intentionally allowed for several reasons:
  * - The class name is still easily recognizable with the single backslash in front.
- * - A "use" takes more space than a dozen backslashes.
+ * - A "use …" takes more space than a dozen backslashes.
  * - This reflects the actual living code style in the Wikibase code bases that contain hundreds of
  *   "\MediaWikiTestCase", "\InvalidArgumentException", "\FauxRequest", and such.
  *
@@ -31,14 +31,26 @@ class FullQualifiedClassNameSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 
 		// Shorten out if:
-		// - There is no namespace before the backslash. This intentionally allows "\Bar".
+		// - There is no namespace before the backslash. This intentionally allows full qualified
+		//   class names in the main namespace.
 		// - There is no class name after the backslash.
 		// - This backslash is not the last one before the class name.
-		// - We are not dealing with a class name but a function.
+		// - What follows is not a class name but a function call. This intentionally allows full
+		//   qualified "\Wikimedia\suppressWarnings()" and such.
 		if ( $tokens[$stackPtr - 1]['code'] !== T_STRING
 			|| $tokens[$stackPtr + 1]['code'] !== T_STRING
 			|| $tokens[$stackPtr + 2]['code'] === T_NS_SEPARATOR
 			|| $tokens[$stackPtr + 2]['code'] === T_OPEN_PARENTHESIS
+		) {
+			return;
+		}
+
+		// Accept full qualified "…Test extends \PHPUnit\Framework\TestCase", because:
+		// - An enforced "…Test extends TestCase" wouldn't be better readable.
+		// - There can't be more than one "… extends …" per file.
+		// - This reflects the living standard in most MediaWiki code bases.
+		if ( $tokens[$stackPtr + 1]['content'] === 'TestCase'
+			&& $tokens[$stackPtr - 1]['content'] === 'Framework'
 		) {
 			return;
 		}
@@ -51,7 +63,7 @@ class FullQualifiedClassNameSniff implements Sniff {
 		}
 
 		$phpcsFile->addError(
-			'Full qualified class name "…\\%s" found, please utilize "use"',
+			'Full qualified class name "…\\%s" found, please utilize "use …"',
 			$stackPtr,
 			'Found',
 			[ $tokens[$stackPtr + 1]['content'] ]

--- a/Wikibase/Tests/Namespaces/FullQualifiedClassName.php
+++ b/Wikibase/Tests/Namespaces/FullQualifiedClassName.php
@@ -30,3 +30,9 @@ class DisallowedFullQualifiedClassName extends SomeNamespace\Example1 {
 
 class DisallowedFullQualifiedClassNameWithBackslash extends \SomeNamespace\Example1 {
 }
+
+class AllowPHPUnitFrameworkTestCaseTest extends PHPUnit\Framework\TestCase {
+}
+
+class AllowPHPUnitFrameworkTestCaseWithBackslashTest extends \PHPUnit\Framework\TestCase {
+}

--- a/Wikibase/Tests/Namespaces/FullQualifiedClassName.php.expected
+++ b/Wikibase/Tests/Namespaces/FullQualifiedClassName.php.expected
@@ -1,2 +1,2 @@
- 28 | ERROR | Full qualified class name "…\Example1" found, please utilize "use"
- 31 | ERROR | Full qualified class name "…\Example1" found, please utilize "use"
+ 28 | ERROR | Full qualified class name "…\Example1" found, please utilize "use …"
+ 31 | ERROR | Full qualified class name "…\Example1" found, please utilize "use …"


### PR DESCRIPTION
This patch fixes an issue @legoktm pointed out in https://phabricator.wikimedia.org/T188011. All reasoning (please see the comment I added to the code for future reference) boils down to this: I find it super-critical to not have any sniffs that actually *conflict* with other sniffs or code styles other Wikimedia developers are using. I realized this is the case here. Personally, I find both classes in the main namespace as well as a single `…Test extends \PHPUnit\Framework\TestCase` in the header of each test acceptable exceptions. These exceptions allow us to apply this custom sniff on much more codebases.