### PR TITLE
Fix (some) false-positives in UnusedUse sniff

### DIFF
--- a/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
+++ b/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
@@ -42,6 +42,8 @@ class UnusedUseSniff implements Sniff {
 
 			if ( ( $token['code'] === T_STRING
 					&& strcasecmp( $token['content'], $className ) === 0
+					&& $tokens[$i - 1]['code'] !== T_DOUBLE_COLON
+					&& $tokens[$i - 1]['code'] !== T_OBJECT_OPERATOR
 				)
 				|| ( $token['code'] === T_DOC_COMMENT_TAG
 					&& preg_match( '/^@(?:expectedException|param|return|throw|type|var)/i', $token['content'] )

--- a/Wikibase/Tests/Namespaces/UnusedUse.php
+++ b/Wikibase/Tests/Namespaces/UnusedUse.php
@@ -58,6 +58,10 @@ class Example implements UsedMain {
 		/* @var $var bool MentionedInComment should not count as usage */
 		$withAComment = new WithAComment();
 		$withADocComment = new WithADocComment();
+
+		// These "unused" are strings for the tokenizer, but not class names
+		PrecededByDoubleColon::unused();
+		$precededByObjectOperator->unused();
 	}
 
 }

--- a/Wikibase/Tests/Namespaces/UnusedUse.php.fixed
+++ b/Wikibase/Tests/Namespaces/UnusedUse.php.fixed
@@ -54,6 +54,10 @@ class Example implements UsedMain {
 		/* @var $var bool MentionedInComment should not count as usage */
 		$withAComment = new WithAComment();
 		$withADocComment = new WithADocComment();
+
+		// These "unused" are strings for the tokenizer, but not class names
+		PrecededByDoubleColon::unused();
+		$precededByObjectOperator->unused();
 	}
 
 }


### PR DESCRIPTION
Currently this sniff checks if the class name from a `use …` appears in a T_STRING token in the later code. Unfortunately T_STRING is very broadly used and does not necessarily refer to a class name. I figured it is very hard and probably not worth trying to find a perfect solution that avoids all false positives, especially because I never run into issues when running this on real-life code. But I think the two exceptional cases in this patch (`…::foo` as well as `…->foo` can never refer to a class `Foo`) are fine to add. They are also the most common ones.