### PR TITLE
Optimize UnusedUse sniff for performance

### DIFF
--- a/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
+++ b/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
@@ -41,13 +41,13 @@ class UnusedUseSniff implements Sniff {
 			$token = $tokens[$i];
 
 			if ( ( $token['code'] === T_STRING
-					&& strcasecmp( $token['content'], $className ) === 0
 					&& $tokens[$i - 1]['code'] !== T_DOUBLE_COLON
 					&& $tokens[$i - 1]['code'] !== T_OBJECT_OPERATOR
+					&& strcasecmp( $token['content'], $className ) === 0
 				)
 				|| ( $token['code'] === T_DOC_COMMENT_TAG
-					&& preg_match( '/^@(?:expectedException|param|return|throw|type|var)/i', $token['content'] )
 					&& $tokens[$i + 2]['code'] === T_DOC_COMMENT_STRING
+					&& preg_match( '/^@(?:expectedException|param|return|throw|type|var)/i', $token['content'] )
 					&& preg_match( '/^' . $varDocPattern, $tokens[$i + 2]['content'] )
 				)
 				|| ( $token['code'] === T_COMMENT


### PR DESCRIPTION
This trivial optimization reduces the amount of calls of the more expensive string comparison functions quite a bit. In a real-life profile run I did strcasecmp() was called 1/3 less. This is relevant because this sniff is currently the most expensive in this codebase here.