### PR TITLE
Update MediaWiki CodeSniffer to version 19

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,12 +2,20 @@
 
 ## 0.5.0 (dev)
 
-* Disallowed PHPDoc tags that end with a colon, e.g. `@todo:`.
+* Updated the base MediaWiki rule set from 16.0.1 to 19.0.0. This adds the following sniffs:
+	* `MediaWiki.Commenting.LicenseComment`
+	* `MediaWiki.Commenting.PhpunitAnnotations`
+	* `MediaWiki.PHP71Features.NullableType`
+	* `MediaWiki.PHP71Features.VoidReturnType`
+* Enabled `MediaWiki.Commenting.MissingCovers`.
+* Made `Wikibase.Namespaces.UnusedUse` aware of PHP7 return types.
+* Added auto-fix for PHPDoc tags that end with a colon, e.g. `@todo:`.
 * Added capitalization and spelling fixes for more PHPDoc tags:
 	* `@covers…`
 	* `@dataProvider`
 	* `@deprecated`
-	* `@expected…`
+	* `@expectedException…`
+* Added a previously missing auto-fix to `Wikibase.Commenting.ClassLevelDocumentation`.
 
 ## 0.4.1 (2018-03-23)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,7 +15,6 @@
 	* `@dataProvider`
 	* `@deprecated`
 	* `@expectedException…`
-* Added a previously missing auto-fix to `Wikibase.Commenting.ClassLevelDocumentation`.
 
 ## 0.4.1 (2018-03-23)
 

--- a/Wikibase/Tests/WikibaseStandardTest.php
+++ b/Wikibase/Tests/WikibaseStandardTest.php
@@ -16,6 +16,8 @@ use SplFileInfo;
  * Test runner for custom Wikibase CodeSniffer sniffs. This is copied from the MediaWiki CodeSniffer
  * code repository, but simplified a lot.
  *
+ * phpcs:disable MediaWiki.Commenting.MissingCovers
+ *
  * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */

--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -10,9 +10,6 @@
 
 		<!-- The function comment sniff is way to rigorous about way to many details that need
 			exceptions:
-			* It complains when "@param <type> $<var>" is not followed by a comment, even if type
-			  and variable name are fully self-explanatory. We do have 3000+ of these in the
-			  Wikibase code base.
 			* It complains about missing documentation on fully self-explanatory function headers
 			  with strict type hints.
 			* It complains about missing documentation if there is a proper @see tag.
@@ -24,10 +21,6 @@
 		<!-- We disagree with the idea of certain characters making comments "illegal" and blocking
 			patches from being merged. This behaves especially bad on code examples. -->
 		<exclude name="MediaWiki.Commenting.IllegalSingleLineComment" />
-
-		<!-- Temporary disabled because it erroneously reports missing @covers tags on abstract base
-			classes. -->
-		<exclude name="MediaWiki.Commenting.MissingCovers" />
 
 		<!-- Individual projects should be free to decide if they want to wait for PHPUnit 6, or
 			start using namespaced class names in advance. -->

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"require": {
 		"php": ">=5.5.9",
-		"mediawiki/mediawiki-codesniffer": "16.0.1"
+		"mediawiki/mediawiki-codesniffer": "19.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^4.8.35"


### PR DESCRIPTION
I did a test run with the Wikibase code base and got a pretty long report containing a few mentions of `join()` now being disallowed, invalid SPDX license tags, and missing `@covers`. Most of what I see looks fine and easily fixable.

~~I believe the `MediaWiki.Commenting.PhpunitAnnotations` sniff does have one or two bugs. It complains about the `trait ClaimsChangeOpDeserializationTester` containing `@dataProvider` tags, but I think this is totally fine. It also complains about `@group` in cases where I think they are needed. Pinging @Umherirrender.~~ All resolved.