### PR TITLE
Add trivial indention fix to ClassLevelDocumentation sniff

### DIFF
--- a/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
+++ b/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
@@ -65,12 +65,17 @@ class ClassLevelDocumentationSniff implements Sniff {
 			"\n"
 		);
 		if ( !$newlines ) {
-			// Recreating the correct indention is hard, that's why this is not fixable here
-			$phpcsFile->addWarning(
+			if ( $phpcsFile->addFixableWarning(
 				'No newline after class level documentation',
 				$stackPtr - 1,
 				'MissingNewline'
-			);
+			) ) {
+				// This fix intentionally does not try to be too clever about non-tab indentions
+				$phpcsFile->fixer->addContent(
+					$previous,
+					$phpcsFile->eolChar . str_repeat( "\t", $tokens[$stackPtr]['level'] )
+				);
+			}
 		} elseif ( $newlines > 1 ) {
 			if ( $phpcsFile->addFixableWarning(
 				'To many newlines after class level documentation',

--- a/Wikibase/Tests/Commenting/ClassLevelDocumentation.php.expected
+++ b/Wikibase/Tests/Commenting/ClassLevelDocumentation.php.expected
@@ -1,5 +1,5 @@
- 17 | WARNING | [ ] No newline after class level documentation
- 22 | WARNING | [ ] No newline after class level documentation
+ 17 | WARNING | [x] No newline after class level documentation
+ 22 | WARNING | [x] No newline after class level documentation
  28 | WARNING | [x] To many newlines after class level documentation
  34 | ERROR   | [x] Regular comment found instead of class level documentation
  38 | ERROR   | [ ] Class level documentation missing
@@ -8,7 +8,7 @@
  47 | ERROR   | [ ] Class level documentation missing
  50 | ERROR   | [ ] Class level documentation missing
  54 | ERROR   | [ ] Class level documentation missing
- 56 | WARNING | [ ] No newline after class level documentation
+ 56 | WARNING | [x] No newline after class level documentation
  59 | WARNING | [x] To many newlines after class level documentation
  66 | ERROR   | [ ] Class level documentation missing
  70 | ERROR   | [ ] Class level documentation is empty

--- a/Wikibase/Tests/Commenting/ClassLevelDocumentation.php.fixed
+++ b/Wikibase/Tests/Commenting/ClassLevelDocumentation.php.fixed
@@ -14,12 +14,14 @@ abstract class DocumentedAbstractClass {
 
 /**
  * Missing newline between comment and class.
- */class MissingNewline {
+ */
+class MissingNewline {
 }
 
 /**
  * Wrong whitespace character between comment and class.
- */ class WrongWhitespace {
+ */
+ class WrongWhitespace {
 }
 
 /**
@@ -52,7 +54,8 @@ class UndocumentedSubClass extends UndocumentedClass {
 namespace UndocumentedNamespace {
 	class UndocumentedClassInNamespace {
 	}
-	/** Doc */class MissingNewlineInNamespace {
+	/** Doc */
+	class MissingNewlineInNamespace {
 	}
 	/** Doc */
 	class ToManyNewlinesInNamespace {


### PR DESCRIPTION
I found a surprisingly trivial solution for the one code comment we argue about in #38. Note I'm intentionally assuming tab-indention here, as this is the agreed on standard anyway.

To respond to the claim in the comment in #38: No, the Wikibase ruleset currently does not contain an auto-fix for indentions as they are relevant in this particular edge-case.