### PR TITLE
Remove misplaced "static" from WikibaseStandardTest

### DIFF
--- a/Wikibase/Tests/WikibaseStandardTest.php
+++ b/Wikibase/Tests/WikibaseStandardTest.php
@@ -21,7 +21,7 @@ use SplFileInfo;
  */
 class WikibaseStandardTest extends TestCase {
 
-	public static function provideTestCases() {
+	public function provideIsolatedTestCases() {
 		$tests = [];
 		$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( __DIR__ ) );
 
@@ -44,9 +44,9 @@ class WikibaseStandardTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider provideTestCases
+	 * @dataProvider provideIsolatedTestCases
 	 */
-	public function testCodeSnifferStandardFiles( $sniff, $file ) {
+	public function testSniffsInIsolation( $sniff, $file ) {
 		$expectedFile = $file . '.expected';
 		$fixedFile = $file . '.fixed';
 


### PR DESCRIPTION
These are minor cleanups split from #39:
* No need to declare anything static in PHPUnit tests.
* Rename the provider and test to make it much more obvious this is testing each sniff in isolation. #39 adds support for integration tests.

I will rebase #39 when this is merged.