### PR TITLE
Auto-fix for missing and wrong `@license` tags

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -2,6 +2,12 @@
 <ruleset>
 	<rule ref="Wikibase" />
 
+	<rule ref="Wikibase.Commenting.ClassLevelDocumentation">
+		<properties>
+			<property name="license" value="GPL-2.0-or-later" />
+		</properties>
+	</rule>
+
 	<file>.</file>
 	<exclude-pattern>Tests/*/</exclude-pattern>
 </ruleset>

--- a/Wikibase/Tests/Integration/LicenseRequired.php
+++ b/Wikibase/Tests/Integration/LicenseRequired.php
@@ -1,0 +1,57 @@
+<?php
+
+// phpcs:property Wikibase\Sniffs\Commenting\ClassLevelDocumentationSniff::$license = MIT
+// phpcs:disable Generic.Files.OneObjectStructurePerFile
+
+class Undocumented {
+}
+
+/**
+ * @todo Add license.
+ */
+class Unlicensed {
+}
+
+/**
+ * @license LGPL-3.0-or-later with unwanted extra text
+ */
+class WrongLicense {
+}
+
+/**
+ * @license LGPL-3.0-or-later
+ * @licence MIT
+ */
+class MultiLicensed {
+}
+
+/**
+ * @inheritDoc
+ */class MisplacedEmptyComment {
+}
+
+/*
+ * @license LGPL-3.0-or-later
+ */
+class NonPhpDocComment {
+}
+
+namespace Nested {
+
+	abstract class Undocumented {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	class EmptyComment {
+	}
+
+	/**
+	 * Multiple sniffs detect this, but no other can fix it.
+	 * @license
+	 */
+	class EmptyLicense {
+	}
+
+}

--- a/Wikibase/Tests/Integration/LicenseRequired.php.expected
+++ b/Wikibase/Tests/Integration/LicenseRequired.php.expected
@@ -1,0 +1,10 @@
+  6 | ERROR   | [x] @license missing
+  9 | ERROR   | [x] @license missing
+ 16 | ERROR   | [x] Wrong @license
+ 23 | ERROR   | [x] Found @licence instead of @license
+ 28 | ERROR   | [x] @license missing
+ 30 | WARNING | [x] No newline after class level documentation
+ 35 | ERROR   | [x] Regular comment found instead of class level documentation
+ 41 | ERROR   | [x] @license missing
+ 44 | ERROR   | [x] @license missing
+ 52 | ERROR   | [x] @license not followed by a license

--- a/Wikibase/Tests/Integration/LicenseRequired.php.fixed
+++ b/Wikibase/Tests/Integration/LicenseRequired.php.fixed
@@ -1,0 +1,67 @@
+<?php
+
+// phpcs:property Wikibase\Sniffs\Commenting\ClassLevelDocumentationSniff::$license = MIT
+// phpcs:disable Generic.Files.OneObjectStructurePerFile
+
+/**
+ * @license MIT
+ */
+class Undocumented {
+}
+
+/**
+ * @todo Add license.
+ * @license MIT
+ */
+class Unlicensed {
+}
+
+/**
+ * @license MIT
+ */
+class WrongLicense {
+}
+
+/**
+ * @license LGPL-3.0-or-later
+ * @license MIT
+ */
+class MultiLicensed {
+}
+
+/**
+ * @inheritDoc
+ * @license MIT
+ */
+class MisplacedEmptyComment {
+}
+
+/**
+ * @license MIT
+ */
+class NonPhpDocComment {
+}
+
+namespace Nested {
+
+	/**
+	 * @license MIT
+	 */
+	abstract class Undocumented {
+	}
+
+	/**
+	 * @inheritDoc
+	 * @license MIT
+	 */
+	class EmptyComment {
+	}
+
+	/**
+	 * Multiple sniffs detect this, but no other can fix it.
+	 * @license MIT
+	 */
+	class EmptyLicense {
+	}
+
+}

--- a/Wikibase/Tests/WikibaseStandardTest.php
+++ b/Wikibase/Tests/WikibaseStandardTest.php
@@ -7,6 +7,7 @@ use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Reporter;
 use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Util\Common;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -47,8 +48,13 @@ class WikibaseStandardTest extends TestCase {
 		);
 		foreach ( $matches as $match ) {
 			list( , $sniffClass, $property, $value ) = $match;
+
 			// Required for reporting
 			$ruleset->setSniffProperty( $sniffClass, $property, $value );
+
+			// Required for fixing
+			$sniffCode = Common::getSniffCode( $sniffClass );
+			$ruleset->ruleset[$sniffCode]['properties'][$property] = $value;
 		}
 
 		$phpCsFile = new DummyFile( $content, $ruleset, $config );


### PR DESCRIPTION
This is an alternative to #38 that aims to avoid the issues pointed out in the discussion.

Note this is a chain of 3 pull requests, and the way GitHub works requires to either merge them in reverse order (#45 first, then #40, and #39 last), or later cherry-pick commits to master that did not ended there.