### PR TITLE
Remove my name where it doesn't apply

### DIFF
--- a/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
+++ b/Wikibase/Sniffs/Commenting/ClassLevelDocumentationSniff.php
@@ -13,7 +13,6 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  * @since 0.2.0
  *
  * @license GPL-2.0-or-later
- * @author Thiemo Kreuz
  */
 class ClassLevelDocumentationSniff implements Sniff {
 

--- a/Wikibase/Tests/WikibaseStandardTest.php
+++ b/Wikibase/Tests/WikibaseStandardTest.php
@@ -17,7 +17,6 @@ use SplFileInfo;
  * code repository, but simplified a lot.
  *
  * @license GPL-2.0-or-later
- * @author Thiemo Kreuz
  */
 class WikibaseStandardTest extends TestCase {
 

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,6 @@
 	"description": "Wikibase CodeSniffer standards",
 	"homepage": "https://www.mediawiki.org/wiki/Wikibase/Coding_conventions",
 	"license": "GPL-2.0-or-later",
-	"authors": [
-		{
-			"name": "Thiemo Kreuz"
-		}
-	],
 	"require": {
 		"php": ">=5.5.9",
 		"mediawiki/mediawiki-codesniffer": "16.0.1"


### PR DESCRIPTION
I'm removing my name as the author of this codebase from all top-level files where it does not apply any more, or will not apply any more soon.

This is part of the handover with @manicki. Please feel free to update this patch and repopulate the authors section in composer.json, e.g. with the [widely used](https://github.com/search?q=%22The+Wikidata+team%22&type=Code) "The Wikidata team". I'm intentionally not doing this myself as it should be your decision.