### PR TITLE
Respect @see references when checking unused uses

### DIFF
--- a/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
+++ b/Wikibase/Sniffs/Namespaces/UnusedUseSniff.php
@@ -35,6 +35,7 @@ class UnusedUseSniff implements Sniff {
 		}
 
 		$className = $tokens[$classNamePtr]['content'];
+		$docTagPattern = 'expectedException|param|return|see|throw|type|var';
 		$varDocPattern = '(?:\S+\s+)?\S*\b' . preg_quote( $className, '/' ) . '\b/i';
 
 		for ( $i = $useEndPtr + 1; $i < $phpcsFile->numTokens; $i++ ) {
@@ -50,7 +51,7 @@ class UnusedUseSniff implements Sniff {
 				)
 				|| ( $token['code'] === T_DOC_COMMENT_TAG
 					&& $tokens[$i + 2]['code'] === T_DOC_COMMENT_STRING
-					&& preg_match( '/^@(?:expectedException|param|return|throw|type|var)/i', $token['content'] )
+					&& preg_match( '/^@(?:' . $docTagPattern . ')/i', $token['content'] )
 					&& preg_match( '/^' . $varDocPattern, $tokens[$i + 2]['content'] )
 				)
 				|| ( $token['code'] === T_COMMENT

--- a/Wikibase/Tests/Namespaces/UnusedUse.php
+++ b/Wikibase/Tests/Namespaces/UnusedUse.php
@@ -21,9 +21,12 @@ use UsedExpectedException;
 use UsedThrows;
 use UsedReturn;
 use UsedPhp7ReturnType;
+use UsedSee;
+use UsedSeeMethod;
 
 /**
  * @group Unused
+ * @see UsedSee
  */
 class Example implements UsedMain {
 
@@ -45,6 +48,7 @@ class Example implements UsedMain {
 	private $prop3;
 
 	/**
+	 * @see UsedSeeMethod::method
 	 * @expectedException UsedExpectedException
 	 * @param int[]|UsedInAnArray[] $arg
 	 * @param bool $arg MentionedInComment should not count as usage

--- a/Wikibase/Tests/Namespaces/UnusedUse.php.fixed
+++ b/Wikibase/Tests/Namespaces/UnusedUse.php.fixed
@@ -17,9 +17,12 @@ use UsedExpectedException;
 use UsedThrows;
 use UsedReturn;
 use UsedPhp7ReturnType;
+use UsedSee;
+use UsedSeeMethod;
 
 /**
  * @group Unused
+ * @see UsedSee
  */
 class Example implements UsedMain {
 
@@ -41,6 +44,7 @@ class Example implements UsedMain {
 	private $prop3;
 
 	/**
+	 * @see UsedSeeMethod::method
 	 * @expectedException UsedExpectedException
 	 * @param int[]|UsedInAnArray[] $arg
 	 * @param bool $arg MentionedInComment should not count as usage


### PR DESCRIPTION
If a class or interface is referenced in an `@see` tag, it should not be reported as unused.

The variable `$docTagPattern` is extracted to avoid an overly long line.

---

This came up in [I600e42302b](https://gerrit.wikimedia.org/r/449155), where CI complained about an unused import even though it was still used in a few documentation comments.