### PR TITLE
Require PHP 7.2+ and MW codesniffer 28.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: php
 dist: trusty
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
 

--- a/Wikibase/Tests/ClassLevelDocumentationSniffTest.php
+++ b/Wikibase/Tests/ClassLevelDocumentationSniffTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\CodeSniffer\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Wikibase\Sniffs\Commenting\ClassLevelDocumentationSniff;
 
 /**
@@ -9,7 +10,7 @@ use Wikibase\Sniffs\Commenting\ClassLevelDocumentationSniff;
  *
  * @license GPL-2.0-or-later
  */
-class ClassLevelDocumentationSniffTest extends \PHPUnit_Framework_TestCase {
+class ClassLevelDocumentationSniffTest extends TestCase {
 
 	public function testAddsCorrectLicenseIfNonePresent() {
 		$givenLicense = 'http://opensource.org/licenses/gpl-license.php GNU Public License';

--- a/Wikibase/ruleset.xml
+++ b/Wikibase/ruleset.xml
@@ -22,10 +22,6 @@
 			patches from being merged. This behaves especially bad on code examples. -->
 		<exclude name="MediaWiki.Commenting.IllegalSingleLineComment" />
 
-		<!-- Individual projects should be free to decide if they want to wait for PHPUnit 6, or
-			start using namespaced class names in advance. -->
-		<exclude name="MediaWiki.Usage.PHPUnitClassUsage" />
-
 		<!-- Starting a function's body with an empty line can be helpful after a very large header.
 			The code is not guaranteed to be easier to read if this is disallowed. -->
 		<exclude name="MediaWiki.WhiteSpace.DisallowEmptyLineFunctions" />

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
 	"homepage": "https://www.mediawiki.org/wiki/Wikibase/Coding_conventions",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=5.5.9",
-		"mediawiki/mediawiki-codesniffer": "19.1.0"
+		"php": ">=7.2.0",
+		"mediawiki/mediawiki-codesniffer": "28.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^4.8.35"


### PR DESCRIPTION
The last version of MW codesniffer enables PHP7+ syntax, and some sniffs to ensure PHPUnit 8 compatibility.