### PR TITLE
Upgrade MediaWiki Code Sniffer from v28 to v29

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.2.0",
-		"mediawiki/mediawiki-codesniffer": "28.0.0"
+		"mediawiki/mediawiki-codesniffer": "29.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.4"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"mediawiki/mediawiki-codesniffer": "28.0.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^4.8.35"
+		"phpunit/phpunit": "^8.4"
 	},
 	"autoload-dev": {
 		"psr-4": {


### PR DESCRIPTION
In particular, this brings in lots of auto-fixes for the migration to PHPUnit 8.